### PR TITLE
feat(ts): upload(13カテゴリ+UploadVideo) / event_stream / executeRaw

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
     "typecheck": "tsc --noEmit",
-    "test": "tsx tests/signing.test.ts && tsx tests/auth_refresh.test.ts && tsx tests/session_file.test.ts && tsx tests/auth.test.ts && tsx tests/retry.test.ts",
+    "test": "tsx tests/signing.test.ts && tsx tests/auth_refresh.test.ts && tsx tests/session_file.test.ts && tsx tests/auth.test.ts && tsx tests/retry.test.ts && tsx tests/upload.test.ts && tsx tests/event_stream.test.ts && tsx tests/execute_raw.test.ts",
     "prepare": "npm run build"
   },
   "engines": {
@@ -34,7 +34,14 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "@types/pngjs": "^6.0.5",
     "tsx": "^4.21.0",
     "typescript": "^5.4.0"
+  },
+  "dependencies": {
+    "image-size": "^1.2.1",
+    "jpeg-js": "^0.4.4",
+    "omggif": "^1.0.10",
+    "pngjs": "^7.0.0"
   }
 }

--- a/packages/typescript/src/channels.ts
+++ b/packages/typescript/src/channels.ts
@@ -1,0 +1,29 @@
+// PORTING.md §10.1: channel identifier strings. The server matches these
+// strings literally when routing later frames — the space after `,` is
+// significant, and the IDs are JSON STRINGS, not numbers. Do not
+// reformat.
+
+export interface Channel {
+  readonly identifier: string;
+}
+
+// ChatRoomChannel — global chat-room signals (new chat requests, chat
+// deletions, forced unsubscribe notices).
+export function chatRoomChannel(): Channel {
+  return { identifier: `{"channel":"ChatRoomChannel"}` };
+}
+
+// MessagesChannel — messages + video_processed events for one chat room.
+export function messagesChannel(roomID: number | string): Channel {
+  return { identifier: `{"channel":"MessagesChannel", "chat_room_id":"${roomID}"}` };
+}
+
+// GroupUpdatesChannel — group state updates across all groups.
+export function groupUpdatesChannel(): Channel {
+  return { identifier: `{"channel":"GroupUpdatesChannel"}` };
+}
+
+// GroupPostsChannel — new posts within one group's timeline.
+export function groupPostsChannel(groupID: number | string): Channel {
+  return { identifier: `{"channel":"GroupPostsChannel", "group_id":"${groupID}"}` };
+}

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -36,7 +36,32 @@ import {
   ThreadsApi,
   UsersApi,
 } from "./gen/apis";
-import { Configuration } from "./gen/runtime";
+import { Configuration, ResponseError, type ApiResponse } from "./gen/runtime";
+
+import { APIError, asAPIError } from "./errors";
+import {
+  type Upload,
+  type UploadCategory,
+  type UploadDeps,
+  type VideoBody,
+  chatBackgroundUpload,
+  chatMessageUpload,
+  groupCoverUpload,
+  groupCreationCoverUpload,
+  groupCreationIconUpload,
+  groupIconUpload,
+  reportUpload,
+  signupAvatarUpload,
+  threadIconUpload,
+  uploadImages,
+  uploadSingleImage,
+  uploadVideo,
+  userAvatarUpload,
+  userCoverUpload,
+  userPostUpload,
+  videoCallSnapshotUpload,
+} from "./upload";
+import { EventStream, type EventStreamOptions, openEventStream } from "./event_stream";
 
 import {
   DEFAULT_ACCEPT_LANGUAGE,
@@ -81,7 +106,16 @@ export interface ClientOptions {
   sessionStore?: SessionStore;
   fetchApi?: typeof fetch;
   retryPolicy?: RetryPolicy;
+  // Injectable WebSocket constructor for openEventStream. Defaults to the
+  // platform global. Tests supply an in-memory pair so the event-stream
+  // suite stays hermetic and dependency-free.
+  webSocketFactory?: WebSocketFactory;
 }
+
+// WebSocketFactory builds a connection for the event stream. The shape is
+// the standard WebSocket constructor; only the slice event_stream.ts uses
+// is required (see WebSocketLike there).
+export type WebSocketFactory = (url: string) => import("./event_stream").WebSocketLike;
 
 // Stub UUIDv4 generator. PORTING.md §14 requires crypto-grade randomness
 // and a failure-MUST-throw contract; a fuller implementation lands when
@@ -121,6 +155,8 @@ export class Client {
   // OAuth /token round-trip (PORTING.md §6.1).
   private _refreshInFlight: Promise<boolean> | null = null;
   private readonly _fetchApi?: typeof fetch;
+  private readonly _webSocketFactory?: WebSocketFactory;
+  private readonly _openStreams = new Set<EventStream>();
   readonly sessionStore?: SessionStore;
 
   // Per-tag API instances. The flat operation surface (PORTING.md §2)
@@ -173,6 +209,7 @@ export class Client {
     this.acceptLanguage = opts.acceptLanguage ?? DEFAULT_ACCEPT_LANGUAGE;
     this.sessionStore = opts.sessionStore;
     this._fetchApi = opts.fetchApi;
+    this._webSocketFactory = opts.webSocketFactory;
     this.retryPolicy = opts.retryPolicy ?? DEFAULT_RETRY_POLICY;
 
     // Middleware order is significant:
@@ -276,7 +313,9 @@ export class Client {
   // tracking) land alongside the auth flow in a later commit. For now
   // close is a no-op so callers can wire it up unconditionally.
   async close(): Promise<void> {
-    /* TODO: cancel lazy fetches and open event streams. */
+    const streams = [...this._openStreams];
+    this._openStreams.clear();
+    await Promise.all(streams.map((s) => s.close().catch(() => undefined)));
   }
 
   /**
@@ -297,6 +336,184 @@ export class Client {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { loginWithEmail } = require("./auth") as typeof import("./auth");
     return loginWithEmail(this);
+  }
+
+  // rawFetch is the unwrapped fetch — no generated middleware, so no
+  // Yay! headers and no `Authorization: Bearer …`. Used for the S3
+  // presigned PUT (whose own signature would clash) and the WebSocket
+  // handshake (which authenticates via the `token` query param).
+  // PORTING.md §6.1: re-issuing through the middleware-wrapped fetch
+  // recurses infinitely — always use this for out-of-band requests.
+  private get _rawFetch(): typeof fetch {
+    const f = this._fetchApi ?? globalThis.fetch;
+    return (input: any, init?: any) => f(input, init);
+  }
+
+  private _uploadDeps(): UploadDeps {
+    return {
+      userID: () => this._userID,
+      getPresignedURLs: async (fileNames: string[]) => {
+        const resp = await this.bucketsAPI.getBucketPresignedUrls({ fileNames });
+        return (resp.presignedUrls ?? []).map((p) => ({
+          filename: p.filename ?? "",
+          url: p.url ?? "",
+        }));
+      },
+      getVideoPresignedURL: async (videoFileName: string) => {
+        const resp = await this.usersAPI.getUserPresignedUrl({ videoFileName });
+        return resp.presignedUrl ?? "";
+      },
+      rawFetch: (url, init) => this._rawFetch(url, init),
+    };
+  }
+
+  // ---- Uploads (PORTING.md §8) ---------------------------------------
+  // Self-user methods read this.userID and reject with a clear "not
+  // logged in" error when it is zero; room/group methods take the ID as
+  // the first argument. Each returns the server-canonical (s3/-prefixed)
+  // filename callers pass back to editUser / createPost / etc.
+
+  uploadAvatarImage(file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), userAvatarUpload(this._requireUserID()), file);
+  }
+
+  uploadCoverImage(file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), userCoverUpload(this._requireUserID()), file);
+  }
+
+  uploadPostImages(files: Upload[]): Promise<string[]> {
+    return uploadImages(this._uploadDeps(), userPostUpload(this._requireUserID()), files);
+  }
+
+  uploadChatMessageImages(roomID: number, files: Upload[]): Promise<string[]> {
+    return uploadImages(
+      this._uploadDeps(),
+      chatMessageUpload(roomID, this._requireUserID()),
+      files,
+    );
+  }
+
+  uploadChatBackgroundImage(roomID: number, file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), chatBackgroundUpload(roomID), file);
+  }
+
+  uploadGroupIconImage(groupID: number, file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), groupIconUpload(groupID), file);
+  }
+
+  uploadGroupCoverImage(groupID: number, file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), groupCoverUpload(groupID), file);
+  }
+
+  uploadThreadIconImage(groupID: number, file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), threadIconUpload(groupID), file);
+  }
+
+  uploadSignupAvatarImage(file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), signupAvatarUpload(), file);
+  }
+
+  uploadGroupCreationIconImage(file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), groupCreationIconUpload(), file);
+  }
+
+  uploadGroupCreationCoverImage(file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), groupCreationCoverUpload(), file);
+  }
+
+  uploadReportImages(files: Upload[]): Promise<string[]> {
+    return uploadImages(this._uploadDeps(), reportUpload(), files);
+  }
+
+  uploadVideoCallSnapshotImage(file: Upload): Promise<string> {
+    return uploadSingleImage(this._uploadDeps(), videoCallSnapshotUpload(), file);
+  }
+
+  uploadVideo(body: VideoBody): Promise<string> {
+    return uploadVideo(this._uploadDeps(), body);
+  }
+
+  /** Lower-level upload entry point for callers that already hold a category. */
+  uploadCategoryImages(category: UploadCategory, files: Upload[]): Promise<string[]> {
+    return uploadImages(this._uploadDeps(), category, files);
+  }
+
+  private _requireUserID(): number {
+    if (!this._userID) {
+      throw new Error("yaylib: not logged in (call loginWithEmail before user-bound uploads)");
+    }
+    return this._userID;
+  }
+
+  // ---- Event stream (PORTING.md §10) ---------------------------------
+
+  /**
+   * Open a multiplexed real-time event channel. The per-connection token
+   * is fetched via getWebSocketToken using the client's current
+   * Authorization, so set the access token first (loginWithEmail /
+   * setTokens / a restored session) — an unauthenticated client surfaces
+   * the underlying 401 as the open error.
+   */
+  async openEventStream(opts: EventStreamOptions = {}): Promise<EventStream> {
+    const stream = await openEventStream(
+      {
+        eventStreamURL: this.eventStreamURL,
+        apiVersionName: this.apiVersionName,
+        getWebSocketToken: async () => {
+          const resp = await this.usersAPI.getWebSocketToken();
+          return resp.token ?? "";
+        },
+        webSocketFactory: this._webSocketFactory,
+      },
+      opts,
+    );
+    this._openStreams.add(stream);
+    void stream.done().finally(() => this._openStreams.delete(stream));
+    return stream;
+  }
+
+  // ---- Raw escape hatch (PORTING.md §11.3) ----------------------------
+
+  /**
+   * executeRaw runs a generated `*Raw` operation and returns the raw
+   * response bytes alongside the HTTP response, bypassing the typed JSON
+   * decode entirely. Contract (PORTING.md §11.3):
+   *
+   *   - HTTP success      → { body, httpResponse, error: undefined }
+   *   - HTTP error (4xx/5xx) → { body, httpResponse, error: APIError }
+   *     so codeOf(error) still works
+   *   - transport failure → { body: undefined, httpResponse: undefined,
+   *     error: APIError }
+   *
+   * Typed JSON-decode failures never propagate — the raw bytes are read
+   * straight off the response.
+   *
+   *   const { body, httpResponse } =
+   *     await client.executeRaw(() => client.usersAPI.getUserTimestampRaw());
+   */
+  async executeRaw<T>(
+    call: () => Promise<ApiResponse<T>>,
+  ): Promise<{ body?: Uint8Array; httpResponse?: Response; error?: APIError }> {
+    try {
+      const api = await call();
+      const body = new Uint8Array(await api.raw.arrayBuffer());
+      return { body, httpResponse: api.raw, error: undefined };
+    } catch (err) {
+      if (err instanceof ResponseError) {
+        const body = err.response
+          ? new Uint8Array(await err.response.arrayBuffer())
+          : new Uint8Array();
+        const error = new APIError({
+          message: err.message || err.response?.statusText || "API error",
+          response: err.response,
+          body,
+          cause: err,
+        });
+        return { body, httpResponse: err.response, error };
+      }
+      // Transport failure (FetchError or anything non-HTTP).
+      return { error: await asAPIError(err) };
+    }
   }
 
   /** Internal — invoked by the auth-refresh middleware (transport.ts). */

--- a/packages/typescript/src/event_stream.ts
+++ b/packages/typescript/src/event_stream.ts
@@ -1,0 +1,639 @@
+// PORTING.md §10: a multiplexed real-time channel — one underlying
+// WebSocket against wss://cable.yay.space, N subscriptions on top. The
+// handshake / subscribe / dispatch flow is Rails-ActionCable-style JSON;
+// the wire constants in §10.1 (dial URL, channel identifier strings,
+// frame inventory, event→DTO map) are pattern-matched server-side and
+// replicated here verbatim — drift produces silent failures.
+//
+// Unlike Go's blocking read loop this port is event-driven (the platform
+// WebSocket is callback-based), but the reconnect state machine,
+// stability threshold, jittered backoff and OnDrop backpressure hook
+// mirror event_stream.go exactly.
+
+import { type Channel } from "./channels";
+import { type Event, decodeEvent } from "./events";
+
+export * from "./channels";
+export * from "./events";
+
+// WebSocketLike is the slice of the standard WebSocket the stream needs.
+// The platform global satisfies it; tests inject an in-memory pair so the
+// suite stays hermetic.
+export interface WebSocketLike {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: unknown }) => void) | null;
+  onclose: ((ev: { code?: number; reason?: string }) => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+}
+
+export interface ReconnectPolicy {
+  // Disabled stops the stream after the first disconnect; subscriptions
+  // terminate with the connection error.
+  disabled?: boolean;
+  // MaxAttempts caps reconnect attempts (excluding the initial dial). 0
+  // means unlimited — opposite of RetryPolicy, because an unattended
+  // event stream wants to keep recovering.
+  maxAttempts?: number;
+  // InitialDelay is the first backoff sleep; each attempt doubles up to
+  // MaxDelay, with full jitter.
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+export interface EventStreamOptions {
+  reconnect?: ReconnectPolicy;
+  // Per-subscription buffer used only while no listener is attached.
+  // Overflow drops the incoming event and fires onDrop. Defaults to 64.
+  eventBuffer?: number;
+  // Caps how long subscribe() waits for confirm_subscription. Default 10s.
+  subscribeTimeoutMs?: number;
+  // Fires when a subscription's buffer is full and an event is dropped —
+  // keeps backpressure observable. Keep it fast.
+  onDrop?: (ev: Event) => void;
+  // How long a fresh connection must stay up before the failure budget
+  // resets (PORTING.md §10: default 30s). Exposed so tests can shrink it.
+  stableThresholdMs?: number;
+  // Caps the dial + welcome handshake. Default 30s.
+  connectTimeoutMs?: number;
+}
+
+export interface EventStreamDeps {
+  eventStreamURL: string;
+  apiVersionName: string;
+  // Fetches the short-lived ws token (GET /v1/users/ws_token via the
+  // wrapped client, so an unauthenticated client surfaces the 401 here).
+  getWebSocketToken(): Promise<string>;
+  webSocketFactory?: (url: string) => WebSocketLike;
+}
+
+interface ResolvedOptions {
+  reconnect: Required<ReconnectPolicy>;
+  eventBuffer: number;
+  subscribeTimeoutMs: number;
+  onDrop?: (ev: Event) => void;
+  stableThresholdMs: number;
+  connectTimeoutMs: number;
+}
+
+function resolveOptions(o: EventStreamOptions): ResolvedOptions {
+  return {
+    reconnect: {
+      disabled: o.reconnect?.disabled ?? false,
+      maxAttempts: o.reconnect?.maxAttempts ?? 0,
+      initialDelayMs:
+        o.reconnect?.initialDelayMs && o.reconnect.initialDelayMs > 0
+          ? o.reconnect.initialDelayMs
+          : 500,
+      maxDelayMs:
+        o.reconnect?.maxDelayMs && o.reconnect.maxDelayMs > 0
+          ? o.reconnect.maxDelayMs
+          : 30_000,
+    },
+    eventBuffer: o.eventBuffer && o.eventBuffer > 0 ? o.eventBuffer : 64,
+    subscribeTimeoutMs:
+      o.subscribeTimeoutMs && o.subscribeTimeoutMs > 0 ? o.subscribeTimeoutMs : 10_000,
+    onDrop: o.onDrop,
+    stableThresholdMs:
+      o.stableThresholdMs && o.stableThresholdMs > 0 ? o.stableThresholdMs : 30_000,
+    connectTimeoutMs:
+      o.connectTimeoutMs && o.connectTimeoutMs > 0 ? o.connectTimeoutMs : 30_000,
+  };
+}
+
+function defaultWebSocketFactory(url: string): WebSocketLike {
+  const WS = (globalThis as { WebSocket?: new (u: string) => unknown }).WebSocket;
+  if (!WS) {
+    throw new Error(
+      "yaylib: no WebSocket implementation available; pass webSocketFactory in ClientOptions",
+    );
+  }
+  return new WS(url) as unknown as WebSocketLike;
+}
+
+interface WireFrame {
+  identifier?: string;
+  type?: string;
+  message?: unknown;
+}
+
+function parseFrame(data: unknown): WireFrame | null {
+  let text: string;
+  if (typeof data === "string") text = data;
+  else if (data instanceof Uint8Array) text = new TextDecoder().decode(data);
+  else if (data instanceof ArrayBuffer) text = new TextDecoder().decode(new Uint8Array(data));
+  else if (data && typeof (data as { toString?: () => string }).toString === "function")
+    text = String(data);
+  else return null;
+  try {
+    return JSON.parse(text) as WireFrame;
+  } catch {
+    return null;
+  }
+}
+
+// Subscription is one active channel subscription. Read events with the
+// callback API (sub.onNewMessage(...), sub.onEvent(...)); the buffer +
+// onDrop hook only matter while no listener is attached.
+export class Subscription {
+  /** @internal */ readonly ident: string;
+  private readonly _stream: EventStream;
+  private readonly _bufferCap: number;
+  private readonly _buffer: Event[] = [];
+  private readonly _listeners = new Set<(ev: Event) => void>();
+
+  private _confirmed = false;
+  private _confirmResolve!: () => void;
+  private _confirmReject!: (err: Error) => void;
+  /** @internal */ readonly confirm: Promise<void>;
+
+  private _closed = false;
+  private _doneResolve!: () => void;
+  readonly done: Promise<void>;
+
+  /** @internal */
+  constructor(stream: EventStream, ident: string, bufferCap: number) {
+    this._stream = stream;
+    this.ident = ident;
+    this._bufferCap = bufferCap;
+    this.confirm = new Promise<void>((resolve, reject) => {
+      this._confirmResolve = resolve;
+      this._confirmReject = reject;
+    });
+    // A confirm that rejects must not become an unhandled rejection if the
+    // caller only ever awaits via awaitConfirm's race.
+    this.confirm.catch(() => undefined);
+    this.done = new Promise<void>((resolve) => {
+      this._doneResolve = resolve;
+    });
+  }
+
+  /** Register a listener for every event on this subscription. */
+  onEvent(fn: (ev: Event) => void): this {
+    this._listeners.add(fn);
+    // Flush anything buffered before the first listener attached.
+    if (this._buffer.length > 0) {
+      const pending = this._buffer.splice(0, this._buffer.length);
+      for (const ev of pending) fn(ev);
+    }
+    return this;
+  }
+
+  private _typed<K extends Event["type"]>(
+    kind: K,
+    fn: (ev: Extract<Event, { type: K }>) => void,
+  ): this {
+    return this.onEvent((ev) => {
+      if (ev.type === kind) fn(ev as Extract<Event, { type: K }>);
+    });
+  }
+
+  onNewMessage(fn: (ev: Extract<Event, { type: "NewMessageEvent" }>) => void): this {
+    return this._typed("NewMessageEvent", fn);
+  }
+  onVideoProcessed(fn: (ev: Extract<Event, { type: "VideoProcessedEvent" }>) => void): this {
+    return this._typed("VideoProcessedEvent", fn);
+  }
+  onChatDeleted(fn: (ev: Extract<Event, { type: "ChatDeletedEvent" }>) => void): this {
+    return this._typed("ChatDeletedEvent", fn);
+  }
+  onTotalChatRequest(fn: (ev: Extract<Event, { type: "TotalChatRequestEvent" }>) => void): this {
+    return this._typed("TotalChatRequestEvent", fn);
+  }
+  onUnsubscribed(fn: (ev: Extract<Event, { type: "UnsubscribedEvent" }>) => void): this {
+    return this._typed("UnsubscribedEvent", fn);
+  }
+  onGroupUpdated(fn: (ev: Extract<Event, { type: "GroupUpdatedEvent" }>) => void): this {
+    return this._typed("GroupUpdatedEvent", fn);
+  }
+  onCallFinished(fn: (ev: Extract<Event, { type: "CallFinishedEvent" }>) => void): this {
+    return this._typed("CallFinishedEvent", fn);
+  }
+  onRaw(fn: (ev: Extract<Event, { type: "RawEvent" }>) => void): this {
+    return this._typed("RawEvent", fn);
+  }
+
+  get closed(): boolean {
+    return this._closed;
+  }
+
+  /** @internal — dispatcher delivers here; never blocks on slow consumers. */
+  deliver(ev: Event): void {
+    if (this._closed) return;
+    if (this._listeners.size > 0) {
+      for (const fn of this._listeners) fn(ev);
+      return;
+    }
+    if (this._buffer.length >= this._bufferCap) {
+      // Buffer full and nobody listening — drop, surface via onDrop.
+      this._stream.onDropEvent(ev);
+      return;
+    }
+    this._buffer.push(ev);
+  }
+
+  /** @internal */
+  confirmOK(): void {
+    if (this._confirmed) return;
+    this._confirmed = true;
+    this._confirmResolve();
+  }
+
+  /** @internal */
+  confirmFail(err: Error): void {
+    if (this._confirmed) return;
+    this._confirmed = true;
+    this._confirmReject(err);
+  }
+
+  /** @internal — terminate because the stream died or rejected the sub. */
+  terminate(err: Error): void {
+    if (this._closed) return;
+    this._closed = true;
+    this.confirmFail(err);
+    this._doneResolve();
+  }
+
+  /**
+   * Unsubscribe sends an unsubscribe command and terminates the
+   * subscription. Safe to call multiple times.
+   */
+  async unsubscribe(): Promise<void> {
+    if (this._closed) return;
+    this._closed = true;
+    this._stream.removeSub(this.ident);
+    try {
+      this._stream.writeCommand("unsubscribe", this.ident);
+    } catch {
+      // Best effort — the server may already be gone.
+    }
+    this._doneResolve();
+  }
+
+  /** @internal — clean shutdown driven by the parent stream's close(). */
+  closeQuietly(): void {
+    if (this._closed) return;
+    this._closed = true;
+    this.confirmFail(new Error("event stream closed"));
+    this._doneResolve();
+  }
+}
+
+export class EventStream {
+  private readonly _deps: EventStreamDeps;
+  private readonly _opts: ResolvedOptions;
+  private readonly _base: string;
+  private readonly _subs = new Map<string, Subscription>();
+
+  private _ws: WebSocketLike | null = null;
+  private _closed = false;
+  private _attempt = 0;
+  private _connectedAt = 0;
+  private _finalErr: Error | undefined;
+  private _sleepCancel: (() => void) | null = null;
+
+  private _doneResolve!: () => void;
+  private readonly _done: Promise<void>;
+
+  /** @internal — use openEventStream(). */
+  constructor(deps: EventStreamDeps, opts: ResolvedOptions) {
+    this._deps = deps;
+    this._opts = opts;
+    this._base = deps.eventStreamURL || "wss://cable.yay.space";
+    this._done = new Promise<void>((resolve) => {
+      this._doneResolve = resolve;
+    });
+  }
+
+  /** @internal */
+  onDropEvent(ev: Event): void {
+    this._opts.onDrop?.(ev);
+  }
+
+  /**
+   * Done resolves once the stream has fully shut down — via close() or
+   * after a permanent failure (reconnect exhausted). Pair with err().
+   */
+  done(): Promise<void> {
+    return this._done;
+  }
+
+  /**
+   * err returns the terminal error after done() resolves: undefined for a
+   * caller-initiated close, the cause otherwise. Returns undefined before
+   * shutdown.
+   */
+  err(): Error | undefined {
+    if (this._closed) return undefined;
+    return this._finalErr;
+  }
+
+  private _setFinalErr(err: Error | undefined): void {
+    this._finalErr = err;
+  }
+
+  private _finalize(err: Error | undefined): void {
+    this._setFinalErr(err);
+    this._terminateAllSubs(err ?? new Error("event stream closed"));
+    this._doneResolve();
+  }
+
+  private _wsURL(token: string): string {
+    // Dial carries NO Authorization header — auth is exclusively the
+    // token query param (PORTING.md §10.1).
+    const u = new URL(this._base);
+    u.searchParams.set("token", token);
+    u.searchParams.set("app_version", this._deps.apiVersionName);
+    return u.toString();
+  }
+
+  /** @internal — performs one dial + welcome handshake. */
+  async connect(timeoutMs: number): Promise<void> {
+    const token = await this._deps.getWebSocketToken();
+    const factory = this._deps.webSocketFactory ?? defaultWebSocketFactory;
+    const ws = factory(this._wsURL(token));
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        try {
+          ws.close();
+        } catch {
+          /* ignore */
+        }
+        reject(new Error("event stream: connect timed out"));
+      }, timeoutMs);
+      const finish = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (err) {
+          try {
+            ws.close();
+          } catch {
+            /* ignore */
+          }
+          reject(err);
+        } else {
+          resolve();
+        }
+      };
+      ws.onopen = () => {
+        /* wait for the welcome frame */
+      };
+      ws.onerror = () => finish(new Error("event stream: socket error during handshake"));
+      ws.onclose = () => finish(new Error("event stream: closed during handshake"));
+      ws.onmessage = (ev) => {
+        const f = parseFrame(ev.data);
+        if (!f) return;
+        if (f.type === "welcome") finish();
+        else if (f.type === "disconnect")
+          finish(new Error("event stream: server disconnect during welcome"));
+        // Any preceding pings are ignored.
+      };
+    });
+
+    const old = this._ws;
+    this._ws = ws;
+    if (old) {
+      try {
+        old.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    this._connectedAt = Date.now();
+    ws.onmessage = (ev) => this._dispatch(ev.data);
+    ws.onerror = null;
+    ws.onclose = () => this._onSocketClosed(new Error("event stream: connection closed"));
+  }
+
+  private _onSocketClosed(err: Error): void {
+    if (this._closed) return;
+    this._setFinalErr(err);
+    if (this._opts.reconnect.disabled) {
+      this._finalize(err);
+      return;
+    }
+    // A connection that stayed up past the stability threshold resets the
+    // failure budget; a flap (welcome + immediate drop) counts toward
+    // MaxAttempts so a misconfigured peer can't reconnect forever.
+    if (this._connectedAt && Date.now() - this._connectedAt >= this._opts.stableThresholdMs) {
+      this._attempt = 0;
+    }
+    void this._reconnect();
+  }
+
+  private _backoff(attempt: number): number {
+    const { initialDelayMs, maxDelayMs } = this._opts.reconnect;
+    let exp = initialDelayMs * 2 ** (attempt - 1);
+    if (!Number.isFinite(exp) || exp <= 0 || exp > maxDelayMs) exp = maxDelayMs;
+    if (exp <= 0) return 0;
+    let delay = Math.floor(Math.random() * exp) + initialDelayMs;
+    if (delay > maxDelayMs) delay = maxDelayMs;
+    return delay;
+  }
+
+  private _sleep(ms: number): Promise<boolean> {
+    if (ms <= 0) return Promise.resolve(!this._closed);
+    return new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => {
+        this._sleepCancel = null;
+        resolve(!this._closed);
+      }, ms);
+      this._sleepCancel = () => {
+        clearTimeout(timer);
+        this._sleepCancel = null;
+        resolve(false);
+      };
+    });
+  }
+
+  private async _reconnect(): Promise<void> {
+    while (!this._closed) {
+      this._attempt++;
+      const max = this._opts.reconnect.maxAttempts;
+      if (max > 0 && this._attempt > max) {
+        const e = new Error(
+          `event stream: reconnect exhausted after ${max} attempts: ${this._finalErr?.message ?? "unknown"}`,
+        );
+        this._finalize(e);
+        return;
+      }
+      const ok = await this._sleep(this._backoff(this._attempt));
+      if (!ok) {
+        this._finalize(this._finalErr);
+        return;
+      }
+      try {
+        await this.connect(this._opts.connectTimeoutMs);
+      } catch (e) {
+        this._setFinalErr(e instanceof Error ? e : new Error(String(e)));
+        continue;
+      }
+      // Reconnected. Re-subscribe everything; the new socket's onclose
+      // re-enters this state machine if it drops again.
+      this._resubscribeAll();
+      return;
+    }
+    this._finalize(this._finalErr);
+  }
+
+  private _dispatch(data: unknown): void {
+    const f = parseFrame(data);
+    if (!f) return;
+    switch (f.type) {
+      case "welcome":
+      case "ping":
+        return;
+      case "disconnect":
+        // Server-requested disconnect — close the socket so onclose
+        // drives the reconnect logic.
+        try {
+          this._ws?.close(1000, "server disconnect");
+        } catch {
+          /* ignore */
+        }
+        return;
+      case "confirm_subscription": {
+        const sub = f.identifier ? this._subs.get(f.identifier) : undefined;
+        sub?.confirmOK();
+        return;
+      }
+      case "reject_subscription": {
+        const sub = f.identifier ? this._subs.get(f.identifier) : undefined;
+        if (sub) {
+          const e = new Error("event stream: subscription rejected");
+          sub.confirmFail(e);
+          sub.terminate(e);
+          this._subs.delete(f.identifier as string);
+        }
+        return;
+      }
+    }
+    // Anything else is an event keyed by identifier.
+    const msg = f.message;
+    if (!msg || typeof msg !== "object") return;
+    const payload = msg as { event?: string; data?: unknown; message?: unknown };
+    const name = payload.event;
+    const body = payload.data ?? payload.message;
+    if (!name || body == null) return;
+    const ev = decodeEvent(name, body);
+    const sub = f.identifier ? this._subs.get(f.identifier) : undefined;
+    sub?.deliver(ev);
+  }
+
+  /** @internal */
+  removeSub(ident: string): void {
+    this._subs.delete(ident);
+  }
+
+  /** @internal — best effort; a re-subscribe runs on the next reconnect. */
+  writeCommand(cmd: "subscribe" | "unsubscribe", identifier: string): void {
+    const ws = this._ws;
+    if (!ws) throw new Error("event stream: not connected");
+    ws.send(JSON.stringify({ command: cmd, identifier }));
+  }
+
+  private _resubscribeAll(): void {
+    for (const sub of this._subs.values()) {
+      try {
+        this.writeCommand("subscribe", sub.ident);
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+
+  private _terminateAllSubs(err: Error): void {
+    const subs = [...this._subs.values()];
+    this._subs.clear();
+    for (const s of subs) s.terminate(err);
+  }
+
+  /**
+   * Subscribe registers the channel and resolves once the server confirms
+   * (or rejects). Concurrent calls for the same channel share the
+   * underlying Subscription.
+   */
+  async subscribe(channel: Channel): Promise<Subscription> {
+    if (this._closed) throw new Error("event stream closed");
+    const ident = channel.identifier;
+    const existing = this._subs.get(ident);
+    if (existing) return this._awaitConfirm(existing, false);
+
+    const sub = new Subscription(this, ident, this._opts.eventBuffer);
+    this._subs.set(ident, sub);
+    try {
+      this.writeCommand("subscribe", ident);
+    } catch (err) {
+      this._subs.delete(ident);
+      throw new Error(
+        `event stream: subscribe ${ident}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return this._awaitConfirm(sub, true);
+  }
+
+  private async _awaitConfirm(sub: Subscription, owned: boolean): Promise<Subscription> {
+    const cleanup = () => {
+      if (owned) this._subs.delete(sub.ident);
+    };
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`event stream: subscribe ${sub.ident}: timed out`)),
+        this._opts.subscribeTimeoutMs,
+      );
+    });
+    const streamDied = this._done.then(() => {
+      throw this._finalErr ?? new Error("event stream closed");
+    });
+    try {
+      await Promise.race([sub.confirm, streamDied, timeout]);
+      return sub;
+    } catch (err) {
+      cleanup();
+      throw err instanceof Error ? err : new Error(String(err));
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Close terminates the stream, all subscriptions and the socket. Safe
+   * to call multiple times.
+   */
+  async close(): Promise<void> {
+    if (this._closed) {
+      await this._done;
+      return;
+    }
+    this._closed = true;
+    if (this._sleepCancel) this._sleepCancel();
+    try {
+      this._ws?.close(1000, "");
+    } catch {
+      /* ignore */
+    }
+    const subs = [...this._subs.values()];
+    this._subs.clear();
+    for (const s of subs) s.closeQuietly();
+    this._doneResolve();
+    await this._done;
+  }
+}
+
+/** @internal — Client.openEventStream() is the public entry point. */
+export async function openEventStream(
+  deps: EventStreamDeps,
+  opts: EventStreamOptions = {},
+): Promise<EventStream> {
+  const resolved = resolveOptions(opts);
+  const stream = new EventStream(deps, resolved);
+  await stream.connect(resolved.connectTimeoutMs);
+  return stream;
+}

--- a/packages/typescript/src/events.ts
+++ b/packages/typescript/src/events.ts
@@ -1,0 +1,112 @@
+// PORTING.md §10: the fixed event inventory. The wire `event` name does
+// NOT always match the SDK-side type name (e.g. `new_post` carries a
+// group-id update, not a post); the SDK names are preserved verbatim so
+// user code stays portable across the Go / TS / Python ports.
+
+export interface NewMessageEvent {
+  readonly type: "NewMessageEvent";
+  // The full chat-message DTO as delivered on the wire. video_thumbnail
+  // _big_url is a WebSocket-only field (absent on the REST Message DTO);
+  // treat it as nullable.
+  readonly message: Record<string, unknown>;
+}
+
+export interface VideoProcessedEvent {
+  readonly type: "VideoProcessedEvent";
+  readonly id: number;
+  readonly videoProcessed: boolean;
+  readonly videoUrl?: string;
+  readonly videoThumbnailUrl?: string;
+  readonly videoThumbnailBigUrl?: string;
+}
+
+export interface ChatDeletedEvent {
+  readonly type: "ChatDeletedEvent";
+  readonly roomId: number;
+}
+
+export interface TotalChatRequestEvent {
+  readonly type: "TotalChatRequestEvent";
+  readonly totalCount: number;
+}
+
+export interface UnsubscribedEvent {
+  readonly type: "UnsubscribedEvent";
+  readonly userIds: number[];
+}
+
+// GroupUpdatedEvent fires on GroupUpdatesChannel / GroupPostsChannel. Note
+// the wire name for the posts case is `new_post` but the payload is a
+// group-id update, not a post.
+export interface GroupUpdatedEvent {
+  readonly type: "GroupUpdatedEvent";
+  readonly groupId: number;
+}
+
+export interface CallFinishedEvent {
+  readonly type: "CallFinishedEvent";
+  readonly id: number;
+}
+
+// RawEvent wraps an event whose discriminator the SDK does not recognize,
+// so callers can still observe new server signals before the SDK is
+// updated.
+export interface RawEvent {
+  readonly type: "RawEvent";
+  readonly name: string;
+  readonly data: unknown;
+}
+
+export type Event =
+  | NewMessageEvent
+  | VideoProcessedEvent
+  | ChatDeletedEvent
+  | TotalChatRequestEvent
+  | UnsubscribedEvent
+  | GroupUpdatedEvent
+  | CallFinishedEvent
+  | RawEvent;
+
+function num(v: unknown): number {
+  return typeof v === "number" ? v : typeof v === "string" ? Number(v) || 0 : 0;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+// decodeEvent maps a server-supplied event name + payload into a concrete
+// Event. Unknown names fall back to RawEvent. Decoding is tolerant
+// (PORTING.md §11): a malformed field degrades to a zero value rather
+// than throwing, so one bad payload never kills the read pump.
+export function decodeEvent(name: string, data: unknown): Event {
+  const d = (data && typeof data === "object" ? data : {}) as Record<string, unknown>;
+  switch (name) {
+    case "new_message":
+      return { type: "NewMessageEvent", message: d };
+    case "video_processed":
+      return {
+        type: "VideoProcessedEvent",
+        id: num(d.id),
+        videoProcessed: d.video_processed === true,
+        videoUrl: str(d.video_url),
+        videoThumbnailUrl: str(d.video_thumbnail_url),
+        videoThumbnailBigUrl: str(d.video_thumbnail_big_url),
+      };
+    case "chat_deleted":
+      return { type: "ChatDeletedEvent", roomId: num(d.room_id) };
+    case "total_chat_request":
+      return { type: "TotalChatRequestEvent", totalCount: num(d.total_count) };
+    case "unsubscribed":
+      return {
+        type: "UnsubscribedEvent",
+        userIds: Array.isArray(d.user_ids) ? (d.user_ids as unknown[]).map(num) : [],
+      };
+    case "new_post":
+      return { type: "GroupUpdatedEvent", groupId: num(d.group_id) };
+    case "conference_call_finished":
+      return { type: "CallFinishedEvent", id: num(d.id) };
+    default:
+      return { type: "RawEvent", name, data };
+  }
+}

--- a/packages/typescript/src/image.ts
+++ b/packages/typescript/src/image.ts
@@ -1,0 +1,417 @@
+// PORTING.md §8: the upload protocol pieces that aren't visible from the
+// category table — filename shaping, source-size probing, and the
+// thumbnail rules. The Yay! server pattern-matches the filenames and
+// DELETES the main image if its thumbnail is missing, statically encoded,
+// or extension-mismatched, so this module mirrors upload.go's behaviour
+// exactly: JPEG/PNG sources produce a shrunk JPEG thumbnail, animated GIF
+// sources stay animated through the resize.
+
+import { decode as jpegDecode, encode as jpegEncode } from "jpeg-js";
+import { GifReader, GifWriter } from "omggif";
+import { PNG } from "pngjs";
+import { imageSize } from "image-size";
+
+// MaxImagesPerUpload is the default per-call cap on multi-image uploads
+// (uploadPostImages, uploadChatMessageImages). uploadReportImages is
+// tighter — the server rejects the 5th image.
+export const MAX_IMAGES_PER_UPLOAD = 9;
+
+// MaxReportImagesPerUpload is the per-call cap on uploadReportImages.
+export const MAX_REPORT_IMAGES_PER_UPLOAD = 4;
+
+// extOf returns the lowercased extension including the leading dot, or ""
+// when the filename has no extension. Mirrors Go's filepath.Ext.
+export function extOf(filename: string): string {
+  const base = filename.slice(filename.lastIndexOf("/") + 1);
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0) return "";
+  return base.slice(dot).toLowerCase();
+}
+
+// contentTypeFor maps a filename extension to the Content-Type sent on the
+// presigned PUT. Unknown extensions fall back to image/jpeg.
+export function contentTypeFor(filename: string): string {
+  switch (extOf(filename)) {
+    case ".png":
+      return "image/png";
+    case ".gif":
+      return "image/gif";
+    case ".mp4":
+      return "video/mp4";
+    default:
+      return "image/jpeg";
+  }
+}
+
+// normalizeImageExt collapses any input filename to one of .jpg, .jpeg,
+// .png, .gif. Anything else (no extension, .heic, odd casings) becomes
+// .jpg, matching upload.go.
+export function normalizeImageExt(filename: string): string {
+  switch (extOf(filename)) {
+    case ".png":
+      return ".png";
+    case ".gif":
+      return ".gif";
+    case ".jpeg":
+      return ".jpeg";
+    case ".jpg":
+      return ".jpg";
+    default:
+      return ".jpg";
+  }
+}
+
+function sizeSuffix(width: number, height: number): string {
+  return width > 0 && height > 0 ? `_size_${width}x${height}` : "";
+}
+
+// imageFilename builds the main-image object key the Yay! server
+// pattern-matches. Empty ext collapses to .jpg; the size suffix is
+// omitted when either dimension is non-positive.
+export function imageFilename(
+  categoryPath: string,
+  prefix: string,
+  unixMillis: number,
+  index: number,
+  ext: string,
+  width: number,
+  height: number,
+): string {
+  const e = ext === "" ? ".jpg" : ext;
+  const body = `${prefix}_${unixMillis}_${index}${sizeSuffix(width, height)}${e}`;
+  return categoryPath === "" ? body : `${categoryPath}/${body}`;
+}
+
+// thumbnailFilename mirrors imageFilename but adds the "thumb_" prefix the
+// server expects for the resized companion. The size suffix carries the
+// *original* image dimensions, not the thumbnail's.
+export function thumbnailFilename(
+  categoryPath: string,
+  prefix: string,
+  unixMillis: number,
+  index: number,
+  ext: string,
+  origWidth: number,
+  origHeight: number,
+): string {
+  const e = ext === "" ? ".jpg" : ext;
+  const body = `thumb_${prefix}_${unixMillis}_${index}${sizeSuffix(origWidth, origHeight)}${e}`;
+  return categoryPath === "" ? body : `${categoryPath}/${body}`;
+}
+
+// videoFilename is the flat key videos use — no category path, no size
+// suffix (PORTING.md §8).
+export function videoFilename(prefix: string, unixMillis: number): string {
+  return `${prefix}_${unixMillis}.mp4`;
+}
+
+const PREFIX_ALPHABET =
+  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+// randomFilenamePrefix returns n characters from [0-9A-Za-z], freshly
+// generated per upload call. A missing crypto source throws rather than
+// fabricating a fixed prefix that would guarantee bucket collisions
+// (upload.go panics for the same reason).
+export function randomFilenamePrefix(n: number): string {
+  const c = globalThis.crypto;
+  if (!c || typeof c.getRandomValues !== "function") {
+    throw new Error("yaylib: crypto.getRandomValues unavailable; refusing to fabricate upload filename");
+  }
+  const buf = new Uint8Array(n);
+  c.getRandomValues(buf);
+  let out = "";
+  for (let i = 0; i < n; i++) {
+    out += PREFIX_ALPHABET[buf[i] % PREFIX_ALPHABET.length];
+  }
+  return out;
+}
+
+// formatYMD matches the "YYYY/M/D" path the server expects in
+// date-bucketed categories — note the un-padded month and day. UTC fields
+// are used so the bucket path is deterministic regardless of host
+// timezone (PORTING.md §8: the server treats the path as a hint).
+export function formatYMD(d: Date): string {
+  return `${d.getUTCFullYear()}/${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+
+// fitInside returns the width/height that fit srcW x srcH inside
+// maxW x maxH while preserving aspect ratio. Sources already smaller than
+// the box are returned unchanged. [0, 0] signals invalid input.
+export function fitInside(
+  srcW: number,
+  srcH: number,
+  maxW: number,
+  maxH: number,
+): [number, number] {
+  if (srcW <= 0 || srcH <= 0) return [0, 0];
+  let scale = 1;
+  const sw = maxW / srcW;
+  if (sw < scale) scale = sw;
+  const sh = maxH / srcH;
+  if (sh < scale) scale = sh;
+  let dstW = Math.floor(srcW * scale);
+  let dstH = Math.floor(srcH * scale);
+  if (dstW < 1) dstW = 1;
+  if (dstH < 1) dstH = 1;
+  return [dstW, dstH];
+}
+
+// probeImageSize reads the native width/height of a JPEG, PNG, or GIF from
+// its header bytes. An undecodable body throws — uploading a body whose
+// size suffix is wrong (or whose required thumbnail can't be built) just
+// triggers server-side moderation deletion, so we surface the failure.
+export function probeImageSize(body: Uint8Array): { width: number; height: number } {
+  let dim: { width?: number; height?: number };
+  try {
+    dim = imageSize(body);
+  } catch (err) {
+    throw new Error(`decode image: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!dim || !dim.width || !dim.height) {
+    throw new Error("decode image: could not read dimensions");
+  }
+  return { width: dim.width, height: dim.height };
+}
+
+interface RGBA {
+  width: number;
+  height: number;
+  data: Uint8Array; // RGBA, length = width*height*4
+}
+
+function decodeToRGBA(body: Uint8Array): RGBA {
+  let type: string | undefined;
+  try {
+    type = imageSize(body).type;
+  } catch {
+    type = undefined;
+  }
+  if (type === "png") {
+    const png = PNG.sync.read(Buffer.from(body));
+    return { width: png.width, height: png.height, data: new Uint8Array(png.data) };
+  }
+  // jpg / anything jpeg-js can read.
+  const img = jpegDecode(body, { useTArray: true, formatAsRGBA: true });
+  return { width: img.width, height: img.height, data: new Uint8Array(img.data) };
+}
+
+// resizeBilinear scales an RGBA buffer to dstW x dstH with bilinear
+// sampling. Exact pixel parity with Go's draw.BiLinear is not required;
+// the server cares about the dimensions and that a thumbnail exists.
+function resizeBilinear(src: RGBA, dstW: number, dstH: number): RGBA {
+  if (dstW === src.width && dstH === src.height) {
+    return { width: dstW, height: dstH, data: new Uint8Array(src.data) };
+  }
+  const out = new Uint8Array(dstW * dstH * 4);
+  const xRatio = src.width > 1 ? (src.width - 1) / Math.max(dstW - 1, 1) : 0;
+  const yRatio = src.height > 1 ? (src.height - 1) / Math.max(dstH - 1, 1) : 0;
+  for (let y = 0; y < dstH; y++) {
+    const sy = y * yRatio;
+    const y0 = Math.floor(sy);
+    const y1 = Math.min(y0 + 1, src.height - 1);
+    const wy = sy - y0;
+    for (let x = 0; x < dstW; x++) {
+      const sx = x * xRatio;
+      const x0 = Math.floor(sx);
+      const x1 = Math.min(x0 + 1, src.width - 1);
+      const wx = sx - x0;
+      const i00 = (y0 * src.width + x0) * 4;
+      const i01 = (y0 * src.width + x1) * 4;
+      const i10 = (y1 * src.width + x0) * 4;
+      const i11 = (y1 * src.width + x1) * 4;
+      const o = (y * dstW + x) * 4;
+      for (let c = 0; c < 4; c++) {
+        const top = src.data[i00 + c] * (1 - wx) + src.data[i01 + c] * wx;
+        const bot = src.data[i10 + c] * (1 - wx) + src.data[i11 + c] * wx;
+        out[o + c] = Math.round(top * (1 - wy) + bot * wy);
+      }
+    }
+  }
+  return { width: dstW, height: dstH, data: out };
+}
+
+export interface Thumbnail {
+  body: Uint8Array;
+  ext: string;
+  contentType: string;
+}
+
+// makeThumbnailFor produces the right kind of thumbnail for the source
+// format. GIF inputs stay animated GIFs (so the avatar/icon keeps moving
+// when the server renders the thumbnail); everything else becomes a JPEG.
+// The returned ext/contentType match the produced bytes, mirroring
+// upload.go's makeThumbnailFor.
+export function makeThumbnailFor(
+  body: Uint8Array,
+  sourceExt: string,
+  maxW: number,
+  maxH: number,
+): Thumbnail {
+  if (sourceExt === ".gif") {
+    return { body: makeGifThumbnail(body, maxW, maxH), ext: ".gif", contentType: "image/gif" };
+  }
+  return { body: makeJpegThumbnail(body, maxW, maxH), ext: ".jpeg", contentType: "image/jpeg" };
+}
+
+// makeJpegThumbnail decodes a JPEG or PNG and re-encodes it as a shrunk
+// JPEG that fits inside maxW x maxH while preserving aspect ratio. Sources
+// already inside the box are returned at their original size — upscaling
+// would only blur the result.
+export function makeJpegThumbnail(body: Uint8Array, maxW: number, maxH: number): Uint8Array {
+  if (maxW <= 0 || maxH <= 0) {
+    throw new Error(`make thumbnail: invalid target size ${maxW}x${maxH}`);
+  }
+  let src: RGBA;
+  try {
+    src = decodeToRGBA(body);
+  } catch (err) {
+    throw new Error(`make thumbnail: decode source image: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const [dstW, dstH] = fitInside(src.width, src.height, maxW, maxH);
+  if (dstW === 0) throw new Error("make thumbnail: empty source image");
+  const scaled = resizeBilinear(src, dstW, dstH);
+  const encoded = jpegEncode({ width: scaled.width, height: scaled.height, data: scaled.data }, 85);
+  return new Uint8Array(encoded.data);
+}
+
+// quantize maps an RGBA buffer to an indexed palette using a popularity
+// palette plus Floyd–Steinberg error diffusion. The palette is whatever
+// fits in <=256 colours; GIF requires a power-of-two palette so it is
+// padded up. Exact dither parity with Go is not required — the contract
+// is "stays an animated GIF of the right size", which the GifWriter
+// reconstruction below satisfies.
+function quantize(
+  rgba: RGBA,
+): { indices: Uint8Array; palette: number[] } {
+  // Build a popularity histogram on a 4-bit-per-channel grid so the
+  // palette stays small and deterministic.
+  const counts = new Map<number, number>();
+  const px = rgba.data;
+  for (let i = 0; i < px.length; i += 4) {
+    const key =
+      ((px[i] >> 4) << 8) | ((px[i + 1] >> 4) << 4) | (px[i + 2] >> 4);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const ranked = [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 256)
+    .map(([key]) => {
+      const r = ((key >> 8) & 0xf) * 17;
+      const g = ((key >> 4) & 0xf) * 17;
+      const b = (key & 0xf) * 17;
+      return [r, g, b] as [number, number, number];
+    });
+  if (ranked.length === 0) ranked.push([0, 0, 0]);
+  // Pad to a power of two (GifWriter requirement).
+  let palSize = 2;
+  while (palSize < ranked.length) palSize <<= 1;
+  while (ranked.length < palSize) ranked.push([0, 0, 0]);
+  const palette = ranked.map(([r, g, b]) => (r << 16) | (g << 8) | b);
+
+  const nearest = (r: number, g: number, b: number): number => {
+    let best = 0;
+    let bestD = Infinity;
+    for (let i = 0; i < ranked.length; i++) {
+      const dr = r - ranked[i][0];
+      const dg = g - ranked[i][1];
+      const db = b - ranked[i][2];
+      const d = dr * dr + dg * dg + db * db;
+      if (d < bestD) {
+        bestD = d;
+        best = i;
+      }
+    }
+    return best;
+  };
+
+  const w = rgba.width;
+  const h = rgba.height;
+  const buf = Float32Array.from(px);
+  const indices = new Uint8Array(w * h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const o = (y * w + x) * 4;
+      const r = Math.max(0, Math.min(255, buf[o]));
+      const g = Math.max(0, Math.min(255, buf[o + 1]));
+      const b = Math.max(0, Math.min(255, buf[o + 2]));
+      const idx = nearest(r, g, b);
+      indices[y * w + x] = idx;
+      const er = r - ranked[idx][0];
+      const eg = g - ranked[idx][1];
+      const eb = b - ranked[idx][2];
+      const spread = (dx: number, dy: number, f: number) => {
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx < 0 || nx >= w || ny < 0 || ny >= h) return;
+        const no = (ny * w + nx) * 4;
+        buf[no] += er * f;
+        buf[no + 1] += eg * f;
+        buf[no + 2] += eb * f;
+      };
+      spread(1, 0, 7 / 16);
+      spread(-1, 1, 3 / 16);
+      spread(0, 1, 5 / 16);
+      spread(1, 1, 1 / 16);
+    }
+  }
+  return { indices, palette };
+}
+
+// makeGifThumbnail decodes an animated GIF, scales every frame down to fit
+// inside maxW x maxH (preserving aspect ratio), and re-encodes the result
+// as a GIF that retains the original animation. If the source already
+// fits inside the box the original bytes are returned untouched, matching
+// upload.go.
+export function makeGifThumbnail(body: Uint8Array, maxW: number, maxH: number): Uint8Array {
+  if (maxW <= 0 || maxH <= 0) {
+    throw new Error(`make thumbnail: invalid target size ${maxW}x${maxH}`);
+  }
+  let reader: GifReader;
+  try {
+    reader = new GifReader(body);
+  } catch (err) {
+    throw new Error(`make thumbnail: decode gif: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const srcW = reader.width;
+  const srcH = reader.height;
+  const [dstW, dstH] = fitInside(srcW, srcH, maxW, maxH);
+  if (dstW === 0) throw new Error("make thumbnail: empty gif");
+  if (dstW === srcW && dstH === srcH) {
+    // Already fits — return the original bytes untouched.
+    return body;
+  }
+
+  const frameCount = reader.numFrames();
+  // Over-allocate the output; GifWriter writes into a fixed buffer.
+  const out = new Uint8Array(dstW * dstH * frameCount * 2 + 1024 + frameCount * 256 * 3);
+  let loop = 0;
+  try {
+    loop = reader.loopCount();
+  } catch {
+    loop = 0;
+  }
+  const writer = new GifWriter(out, dstW, dstH, { loop: loop >= 0 ? loop : 0 });
+
+  // omggif's decodeAndBlitFrameRGBA composites each frame onto the running
+  // canvas honouring disposal, so we always get a full-canvas RGBA frame —
+  // the same invariant upload.go establishes by drawing onto a full RGBA
+  // canvas before resizing.
+  const canvas = new Uint8Array(srcW * srcH * 4);
+  for (let i = 0; i < frameCount; i++) {
+    const info = reader.frameInfo(i);
+    reader.decodeAndBlitFrameRGBA(i, canvas);
+    const scaled = resizeBilinear(
+      { width: srcW, height: srcH, data: canvas },
+      dstW,
+      dstH,
+    );
+    const { indices, palette } = quantize(scaled);
+    writer.addFrame(0, 0, dstW, dstH, indices, {
+      palette,
+      delay: info.delay,
+      disposal: 0,
+    });
+  }
+  const len = writer.end();
+  return out.slice(0, len);
+}

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -56,3 +56,41 @@ export {
   type RetryPolicy,
   DEFAULT_RETRY_POLICY,
 } from "./retry";
+
+export {
+  type Upload,
+  type UploadCategory,
+  type VideoBody,
+  MAX_IMAGES_PER_UPLOAD,
+  MAX_REPORT_IMAGES_PER_UPLOAD,
+} from "./upload";
+
+export {
+  type Channel,
+  chatRoomChannel,
+  messagesChannel,
+  groupUpdatesChannel,
+  groupPostsChannel,
+} from "./channels";
+
+export type {
+  Event,
+  NewMessageEvent,
+  VideoProcessedEvent,
+  ChatDeletedEvent,
+  TotalChatRequestEvent,
+  UnsubscribedEvent,
+  GroupUpdatedEvent,
+  CallFinishedEvent,
+  RawEvent,
+} from "./events";
+
+export {
+  EventStream,
+  Subscription,
+  type EventStreamOptions,
+  type ReconnectPolicy,
+  type WebSocketLike,
+} from "./event_stream";
+
+export { type WebSocketFactory } from "./client";

--- a/packages/typescript/src/upload.ts
+++ b/packages/typescript/src/upload.ts
@@ -1,0 +1,415 @@
+// PORTING.md §8: the thirteen typed upload categories + uploadVideo. The
+// category table (method ↔ bucket path ↔ thumbnail size ↔ file cap) is
+// replicated from upload.go with the same names and values; the wire
+// pieces that aren't visible from the table (filename shaping, the s3/
+// canonical-name contract, the animated-GIF thumbnail rule) live in
+// image.ts.
+//
+// The presigned PUT bypasses the generated middleware chain entirely: the
+// headers/auth middleware would inject `Authorization: Bearer …` and the
+// Yay! headers, which conflict with the presigned URL's own signature and
+// (per the leak test) must never reach S3. Presigned-URL issuance and the
+// ws-token fetch still go through the wrapped client so they carry auth
+// and retry, exactly as upload.go routes them through the normal client.
+
+import {
+  MAX_IMAGES_PER_UPLOAD,
+  MAX_REPORT_IMAGES_PER_UPLOAD,
+  contentTypeFor,
+  formatYMD,
+  imageFilename,
+  makeThumbnailFor,
+  normalizeImageExt,
+  probeImageSize,
+  randomFilenamePrefix,
+  thumbnailFilename,
+  videoFilename,
+} from "./image";
+
+export { MAX_IMAGES_PER_UPLOAD, MAX_REPORT_IMAGES_PER_UPLOAD };
+
+// Upload is a single file passed to one of the upload<Xxx>Image[s]
+// methods. `filename` is used to derive the extension and Content-Type;
+// `body` is buffered fully before the request is issued (the thumbnail
+// step needs the whole image anyway).
+export interface Upload {
+  filename: string;
+  body: Uint8Array | ArrayBuffer | Blob;
+}
+
+// VideoBody is the single byte stream uploadVideo accepts. A Blob carries
+// its own length and streams directly; the other shapes are buffered
+// because the presigned PUT needs a known Content-Length.
+export type VideoBody = Blob | Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>;
+
+// UploadCategory selects the bucket-side path prefix and thumbnail
+// dimensions for one upload kind. Callers never construct these directly —
+// the typed Client methods know which category they correspond to.
+export interface UploadCategory {
+  // path returns the category-specific prefix. `now` is shared across
+  // every file in a multi-image call so date-bucketed categories get one
+  // consistent timestamp.
+  path(now: Date): string;
+  // thumbnail returns [w, h, true] for the thumbnail box, or [0, 0,
+  // false] for categories that never produce a thumbnail.
+  thumbnail(): [number, number, boolean];
+  // maxFiles caps how many images this category accepts in one call.
+  maxFiles(): number;
+}
+
+const DEFAULT_MAX_FILES = MAX_IMAGES_PER_UPLOAD;
+
+export function userAvatarUpload(userID: number): UploadCategory {
+  return {
+    path: () => `user/${userID}/avatar`,
+    thumbnail: () => [200, 200, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function userCoverUpload(userID: number): UploadCategory {
+  return {
+    path: () => `user/${userID}/cover`,
+    thumbnail: () => [300, 150, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function userPostUpload(userID: number): UploadCategory {
+  return {
+    path: (now) => `user/${userID}/posts/${formatYMD(now)}`,
+    thumbnail: () => [450, 450, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function chatMessageUpload(roomID: number, userID: number): UploadCategory {
+  return {
+    path: (now) => `chatroom/${roomID}/user/${userID}/messages/${formatYMD(now)}`,
+    thumbnail: () => [450, 450, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function chatBackgroundUpload(roomID: number): UploadCategory {
+  return {
+    path: () => `chatroom/${roomID}/background`,
+    thumbnail: () => [200, 200, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function groupIconUpload(groupID: number): UploadCategory {
+  return {
+    path: () => `group/${groupID}/icon`,
+    thumbnail: () => [300, 300, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function groupCoverUpload(groupID: number): UploadCategory {
+  return {
+    path: () => `group/${groupID}/cover`,
+    thumbnail: () => [300, 300, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function groupCreationIconUpload(): UploadCategory {
+  return {
+    path: (now) => `group/create/icon/${formatYMD(now)}`,
+    thumbnail: () => [300, 300, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function groupCreationCoverUpload(): UploadCategory {
+  return {
+    path: (now) => `group/create/cover/${formatYMD(now)}`,
+    thumbnail: () => [300, 300, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function signupAvatarUpload(): UploadCategory {
+  return {
+    path: (now) => `user/create/${formatYMD(now)}`,
+    thumbnail: () => [200, 200, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function threadIconUpload(groupID: number): UploadCategory {
+  return {
+    path: (now) => `group/${groupID}/threads/${formatYMD(now)}`,
+    thumbnail: () => [300, 300, true],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+export function reportUpload(): UploadCategory {
+  return {
+    path: (now) => `report/${formatYMD(now)}`,
+    thumbnail: () => [450, 450, true],
+    maxFiles: () => MAX_REPORT_IMAGES_PER_UPLOAD,
+  };
+}
+
+export function videoCallSnapshotUpload(): UploadCategory {
+  return {
+    path: (now) => `video_call_snapshot/${formatYMD(now)}`,
+    thumbnail: () => [0, 0, false],
+    maxFiles: () => DEFAULT_MAX_FILES,
+  };
+}
+
+// PresignedURL is the shape both presigned endpoints hand back per file.
+export interface PresignedURL {
+  filename?: string | null;
+  url?: string | null;
+}
+
+// UploadDeps is the slice of Client behaviour the upload core needs. The
+// Client supplies it; keeping it abstract avoids a client.ts <-> upload.ts
+// import cycle and makes the flow unit-testable.
+export interface UploadDeps {
+  userID(): number;
+  getPresignedURLs(fileNames: string[]): Promise<PresignedURL[]>;
+  getVideoPresignedURL(videoFileName: string): Promise<string>;
+  // rawFetch bypasses the generated middleware chain — see file header.
+  rawFetch(url: string, init: RequestInit): Promise<Response>;
+}
+
+function requireUserID(deps: UploadDeps): number {
+  const uid = deps.userID();
+  if (!uid) {
+    throw new Error("yaylib: not logged in (call loginWithEmail before user-bound uploads)");
+  }
+  return uid;
+}
+
+async function toBytes(body: Uint8Array | ArrayBuffer | Blob): Promise<Uint8Array> {
+  if (body instanceof Uint8Array) return body;
+  if (body instanceof ArrayBuffer) return new Uint8Array(body);
+  // Blob
+  return new Uint8Array(await body.arrayBuffer());
+}
+
+interface PutJob {
+  body: Uint8Array;
+  filename: string;
+  contentType: string;
+}
+
+async function putToPresignedURL(
+  deps: UploadDeps,
+  rawURL: string,
+  body: Uint8Array | Blob,
+  size: number,
+  contentType: string,
+  signal: AbortSignal,
+): Promise<void> {
+  let res: Response;
+  try {
+    // size is unused at the header level: fetch derives Content-Length
+    // from the Uint8Array/Blob body, and setting it manually trips
+    // undici's duplicate-header guard. The presigned URL signs only the
+    // host, so a matching Content-Type is all S3 intermediaries need.
+    void size;
+    res = await deps.rawFetch(rawURL, {
+      method: "PUT",
+      headers: { "Content-Type": contentType },
+      body: body as unknown as BodyInit,
+      signal,
+    });
+  } catch (err) {
+    throw new Error(`PUT failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (Math.floor(res.status / 100) !== 2) {
+    let preview = "";
+    try {
+      preview = (await res.text()).slice(0, 512).trim();
+    } catch {
+      /* ignore */
+    }
+    throw new Error(`PUT ${res.status}: ${preview}`);
+  }
+}
+
+// uploadImages performs the full presigned-URL + parallel-PUT dance shared
+// by every image-upload method, mirroring upload.go's uploadImages. The
+// returned names are the server-canonical (s3/-prefixed) main-image names;
+// thumbnails live at sibling paths the server resolves automatically.
+export async function uploadImages(
+  deps: UploadDeps,
+  category: UploadCategory,
+  files: Upload[],
+): Promise<string[]> {
+  if (!category) throw new Error("yaylib: upload requires a category");
+  if (!files || files.length === 0) {
+    throw new Error("yaylib: upload requires at least one file");
+  }
+  const cap = category.maxFiles();
+  if (files.length > cap) {
+    throw new Error(`yaylib: this upload accepts at most ${cap} files (got ${files.length})`);
+  }
+
+  const now = new Date();
+  const prefix = randomFilenamePrefix(16);
+  const ts = now.getTime();
+  const categoryPath = category.path(now);
+  const [thumbW, thumbH, hasThumb] = category.thumbnail();
+
+  const mainJobs: PutJob[] = [];
+  const thumbJobs: PutJob[] = [];
+
+  for (let i = 0; i < files.length; i++) {
+    let body: Uint8Array;
+    try {
+      body = await toBytes(files[i].body);
+    } catch (err) {
+      throw new Error(`yaylib: read file ${i}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    const ext = normalizeImageExt(files[i].filename);
+    // A failed decode means the size suffix would be wrong and the body
+    // can't be thumbnailed; uploading it anyway just triggers server-side
+    // moderation deletion, so surface the error.
+    let w: number;
+    let h: number;
+    try {
+      const dim = probeImageSize(body);
+      w = dim.width;
+      h = dim.height;
+    } catch (err) {
+      throw new Error(`yaylib: decode image ${i}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    const mainName = imageFilename(categoryPath, prefix, ts, i, ext, w, h);
+    mainJobs.push({ body, filename: mainName, contentType: contentTypeFor(mainName) });
+
+    if (hasThumb) {
+      let thumb;
+      try {
+        thumb = makeThumbnailFor(body, ext, thumbW, thumbH);
+      } catch (err) {
+        // A missing/mismatched thumbnail makes the server delete the main
+        // asset too, so fail loudly instead of silently skipping it.
+        throw new Error(`yaylib: make thumbnail for image ${i}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      const thumbName = thumbnailFilename(categoryPath, prefix, ts, i, thumb.ext, w, h);
+      thumbJobs.push({ body: thumb.body, filename: thumbName, contentType: thumb.contentType });
+    }
+  }
+
+  const allJobs = [...mainJobs, ...thumbJobs];
+  const allFileNames = allJobs.map((j) => j.filename);
+
+  let urls: PresignedURL[];
+  try {
+    urls = await deps.getPresignedURLs(allFileNames);
+  } catch (err) {
+    throw new Error(`yaylib: get presigned urls: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (urls.length !== allJobs.length) {
+    throw new Error(`yaylib: presigned urls count mismatch (want ${allJobs.length} got ${urls.length})`);
+  }
+
+  // Parallel PUT. The first failure aborts the still-running PUTs so they
+  // exit promptly instead of finishing their now-pointless bodies.
+  const controller = new AbortController();
+  let firstErr: Error | undefined;
+  await Promise.all(
+    allJobs.map(async (job, i) => {
+      const rawURL = urls[i].url ?? "";
+      try {
+        if (rawURL === "") {
+          throw new Error(`yaylib: upload ${job.filename}: empty presigned url`);
+        }
+        await putToPresignedURL(deps, rawURL, job.body, job.body.byteLength, job.contentType, controller.signal);
+      } catch (err) {
+        if (!firstErr) {
+          firstErr = err instanceof Error ? err : new Error(String(err));
+          if (!firstErr.message.startsWith("yaylib:")) {
+            firstErr = new Error(`yaylib: upload ${job.filename}: ${firstErr.message}`);
+          }
+          controller.abort();
+        }
+      }
+    }),
+  );
+  if (firstErr) throw firstErr;
+
+  // The server normalizes each filename (typically an "s3/" prefix
+  // marking it as a freshly-uploaded object). That canonical value — not
+  // the client-side path — is what editUser / createPost expect back.
+  const out: string[] = [];
+  for (let i = 0; i < files.length; i++) {
+    out.push(urls[i].filename ?? "");
+  }
+  return out;
+}
+
+export async function uploadSingleImage(
+  deps: UploadDeps,
+  category: UploadCategory,
+  file: Upload,
+): Promise<string> {
+  const names = await uploadImages(deps, category, [file]);
+  return names[0];
+}
+
+async function sizedBody(body: VideoBody): Promise<{ body: Uint8Array | Blob; size: number }> {
+  if (body instanceof Blob) return { body, size: body.size };
+  if (body instanceof Uint8Array) return { body, size: body.byteLength };
+  if (body instanceof ArrayBuffer) {
+    const u = new Uint8Array(body);
+    return { body: u, size: u.byteLength };
+  }
+  // ReadableStream — buffer fully so the PUT has a known Content-Length.
+  const chunks: Uint8Array[] = [];
+  const reader = body.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  let total = 0;
+  for (const c of chunks) total += c.byteLength;
+  const merged = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    merged.set(c, off);
+    off += c.byteLength;
+  }
+  return { body: merged, size: total };
+}
+
+// uploadVideo uploads a single MP4 stream and returns the filename to pass
+// back as video_file_name. Unlike images the video presigned endpoint
+// does not return a canonical filename, so the random name the SDK
+// generates is what callers hand to createPost / sendChatMessage
+// (PORTING.md §8).
+export async function uploadVideo(deps: UploadDeps, body: VideoBody | null | undefined): Promise<string> {
+  if (body == null) throw new Error("yaylib: uploadVideo: body is nil");
+  const { body: stream, size } = await sizedBody(body);
+  const name = videoFilename(randomFilenamePrefix(16), Date.now());
+
+  let rawURL: string;
+  try {
+    rawURL = await deps.getVideoPresignedURL(name);
+  } catch (err) {
+    throw new Error(`yaylib: get presigned url: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (rawURL === "") throw new Error("yaylib: empty presigned url");
+
+  const controller = new AbortController();
+  try {
+    await putToPresignedURL(deps, rawURL, stream, size, "video/mp4", controller.signal);
+  } catch (err) {
+    throw new Error(`yaylib: upload video: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return name;
+}
+
+// requireUserIDFor is exported so the Client's user-bound methods can
+// enforce the "not logged in" contract before doing any work.
+export { requireUserID };

--- a/packages/typescript/src/vendor.d.ts
+++ b/packages/typescript/src/vendor.d.ts
@@ -1,0 +1,55 @@
+// Ambient declarations for the pure-JS image codecs that ship no types.
+// Only the slices of each API the upload pipeline uses are declared.
+
+declare module "jpeg-js" {
+  export interface RawImageData {
+    width: number;
+    height: number;
+    data: Uint8Array;
+  }
+  export function decode(
+    data: Uint8Array | ArrayBuffer | Buffer,
+    opts?: { useTArray?: boolean; formatAsRGBA?: boolean },
+  ): RawImageData;
+  export function encode(
+    img: { width: number; height: number; data: Uint8Array | Buffer },
+    quality?: number,
+  ): { width: number; height: number; data: Uint8Array };
+}
+
+declare module "omggif" {
+  export class GifReader {
+    constructor(buf: Uint8Array);
+    width: number;
+    height: number;
+    numFrames(): number;
+    loopCount(): number;
+    frameInfo(frame: number): {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      delay: number;
+      disposal: number;
+      transparent_index: number | null;
+    };
+    decodeAndBlitFrameRGBA(frame: number, pixels: Uint8Array | Uint8ClampedArray): void;
+  }
+  export class GifWriter {
+    constructor(
+      buf: Uint8Array | number[],
+      width: number,
+      height: number,
+      gopts?: { loop?: number; palette?: number[] },
+    );
+    addFrame(
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+      indexedPixels: Uint8Array | number[],
+      opts?: { palette?: number[]; delay?: number; disposal?: number; transparent?: number },
+    ): number;
+    end(): number;
+  }
+}

--- a/packages/typescript/tests/event_stream.test.ts
+++ b/packages/typescript/tests/event_stream.test.ts
@@ -1,0 +1,528 @@
+// Event-stream parity tests (PORTING.md §10). Ports event_stream_test.go.
+// The WebSocket transport is injected (webSocketFactory) so the suite is
+// hermetic — no real socket, no `ws` dependency — exactly as the upload /
+// retry suites stand up in-process HTTP servers.
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { Client } from "../src/client";
+import {
+  type EventStream,
+  type WebSocketLike,
+  openEventStream,
+} from "../src/event_stream";
+import {
+  chatRoomChannel,
+  groupUpdatesChannel,
+} from "../src/channels";
+
+let failed = 0;
+function assert(name: string, cond: boolean, detail = ""): void {
+  if (cond) console.log(`PASS ${name}`);
+  else {
+    failed++;
+    console.log(`FAIL ${name}${detail ? `\n  ${detail}` : ""}`);
+  }
+}
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+async function waitUntil(pred: () => boolean, timeoutMs = 3000): Promise<boolean> {
+  const end = Date.now() + timeoutMs;
+  while (Date.now() < end) {
+    if (pred()) return true;
+    await sleep(10);
+  }
+  return pred();
+}
+
+// ---- in-memory WebSocket pair -----------------------------------------
+
+type Frame = Record<string, unknown>;
+
+class Session {
+  ws!: FakeWS;
+  private received: Frame[] = [];
+  private waiters: ((f: Frame) => void)[] = [];
+  recv(obj: Frame): void {
+    const w = this.waiters.shift();
+    if (w) w(obj);
+    else this.received.push(obj);
+  }
+  next(): Promise<Frame> {
+    const r = this.received.shift();
+    return r ? Promise.resolve(r) : new Promise((res) => this.waiters.push(res));
+  }
+  send(obj: Frame): void {
+    setTimeout(() => this.ws._msg(JSON.stringify(obj)), 0);
+  }
+  welcome(): void {
+    this.send({ type: "welcome", sid: "sid" });
+  }
+  confirm(id: string): void {
+    this.send({ identifier: id, type: "confirm_subscription" });
+  }
+  reject(id: string): void {
+    this.send({ identifier: id, type: "reject_subscription" });
+  }
+  pushEvent(id: string, event: string, data: unknown): void {
+    this.send({ identifier: id, message: { event, data } });
+  }
+  close(): void {
+    setTimeout(() => this.ws._drop(), 0);
+  }
+}
+
+class FakeWS implements WebSocketLike {
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: ((ev: { code?: number; reason?: string }) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  private _closed = false;
+  constructor(
+    public url: string,
+    session: Session,
+    onConnect: (s: Session) => void,
+  ) {
+    session.ws = this;
+    setTimeout(() => {
+      if (this._closed) return;
+      this.onopen?.({});
+      onConnect(session);
+    }, 0);
+  }
+  send(data: string): void {
+    try {
+      (this._session as Session).recv(JSON.parse(data));
+    } catch {
+      /* ignore */
+    }
+  }
+  private _session!: Session;
+  bind(s: Session): void {
+    this._session = s;
+  }
+  close(): void {
+    if (this._closed) return;
+    this._closed = true;
+    setTimeout(() => this.onclose?.({}), 0);
+  }
+  _msg(text: string): void {
+    if (!this._closed) this.onmessage?.({ data: text });
+  }
+  _drop(): void {
+    if (this._closed) return;
+    this._closed = true;
+    this.onclose?.({});
+  }
+}
+
+class Hub {
+  urls: string[] = [];
+  connections = 0;
+  constructor(private onConnect: (s: Session) => void) {}
+  factory = (url: string): WebSocketLike => {
+    this.urls.push(url);
+    this.connections++;
+    const session = new Session();
+    const ws = new FakeWS(url, session, this.onConnect);
+    ws.bind(session);
+    return ws;
+  };
+}
+
+function streamDeps(hub: Hub, token = "test-token") {
+  return {
+    eventStreamURL: "ws://cable.test",
+    apiVersionName: "4.26",
+    getWebSocketToken: async () => token,
+    webSocketFactory: hub.factory,
+  };
+}
+
+const FAST_RECONNECT = { initialDelayMs: 20, maxDelayMs: 50 };
+
+// ---- scenarios --------------------------------------------------------
+
+async function subscribeAndReceiveEvent(): Promise<void> {
+  const hub = new Hub((s) => {
+    s.welcome();
+    void (async () => {
+      const msg = await s.next();
+      assert("subscribe&recv: first command is subscribe", msg.command === "subscribe");
+      s.confirm(msg.identifier as string);
+      s.pushEvent(msg.identifier as string, "chat_deleted", { room_id: 123 });
+    })();
+  });
+  const conn = await openEventStream(streamDeps(hub), { reconnect: { disabled: true } });
+  const sub = await conn.subscribe(chatRoomChannel());
+  let roomId = -1;
+  sub.onChatDeleted((ev) => {
+    roomId = ev.roomId;
+  });
+  await waitUntil(() => roomId === 123);
+  assert("subscribe&recv: ChatDeletedEvent room_id=123", roomId === 123, `roomId=${roomId}`);
+  await conn.close();
+}
+
+async function rejectedSubscription(): Promise<void> {
+  const hub = new Hub((s) => {
+    s.welcome();
+    void (async () => {
+      const msg = await s.next();
+      s.reject(msg.identifier as string);
+    })();
+  });
+  const conn = await openEventStream(streamDeps(hub), { reconnect: { disabled: true } });
+  let threw = false;
+  try {
+    await conn.subscribe(chatRoomChannel());
+  } catch {
+    threw = true;
+  }
+  assert("rejected subscription: subscribe() rejects", threw);
+  await conn.close();
+}
+
+async function multipleChannels(): Promise<void> {
+  const hub = new Hub((s) => {
+    s.welcome();
+    void (async () => {
+      for (let i = 0; i < 2; i++) {
+        const msg = await s.next();
+        s.confirm(msg.identifier as string);
+      }
+      s.pushEvent(`{"channel":"ChatRoomChannel"}`, "total_chat_request", { total_count: 7 });
+      s.pushEvent(`{"channel":"GroupUpdatesChannel"}`, "new_post", { group_id: 42 });
+    })();
+  });
+  const conn = await openEventStream(streamDeps(hub), { reconnect: { disabled: true } });
+  let chat = 0;
+  let group = 0;
+  const s1 = await conn.subscribe(chatRoomChannel());
+  s1.onTotalChatRequest((ev) => {
+    chat = ev.totalCount;
+  });
+  const s2 = await conn.subscribe(groupUpdatesChannel());
+  s2.onGroupUpdated((ev) => {
+    group = ev.groupId;
+  });
+  await waitUntil(() => chat === 7 && group === 42);
+  assert("multi-channel: chat=7 group=42", chat === 7 && group === 42, `chat=${chat} group=${group}`);
+  await conn.close();
+}
+
+async function reconnectAfterServerClose(): Promise<void> {
+  let attempts = 0;
+  const hub = new Hub((s) => {
+    const n = ++attempts;
+    s.welcome();
+    void (async () => {
+      const msg = await s.next();
+      s.confirm(msg.identifier as string);
+      if (n === 1) {
+        s.close();
+        return;
+      }
+      s.pushEvent(msg.identifier as string, "chat_deleted", { room_id: 999 });
+    })();
+  });
+  const conn = await openEventStream(streamDeps(hub), { reconnect: FAST_RECONNECT });
+  const sub = await conn.subscribe(chatRoomChannel());
+  let roomId = -1;
+  sub.onChatDeleted((ev) => {
+    roomId = ev.roomId;
+  });
+  await waitUntil(() => roomId === 999, 5000);
+  assert("reconnect: event after re-subscribe (room_id=999)", roomId === 999, `roomId=${roomId}`);
+  assert("reconnect: server saw >=2 connections", attempts >= 2, `attempts=${attempts}`);
+  await conn.close();
+}
+
+async function unsubscribe(): Promise<void> {
+  let sawUnsub = false;
+  const hub = new Hub((s) => {
+    s.welcome();
+    void (async () => {
+      const msg = await s.next();
+      s.confirm(msg.identifier as string);
+      for (;;) {
+        const n = await s.next();
+        if (n.command === "unsubscribe") {
+          sawUnsub = true;
+          return;
+        }
+      }
+    })();
+  });
+  const conn = await openEventStream(streamDeps(hub), { reconnect: { disabled: true } });
+  const sub = await conn.subscribe(chatRoomChannel());
+  await sub.unsubscribe();
+  await sub.done;
+  await waitUntil(() => sawUnsub);
+  assert("unsubscribe: server saw unsubscribe command", sawUnsub);
+  assert("unsubscribe: sub.done resolved", sub.closed);
+  await conn.close();
+}
+
+async function subscribeTimeout(): Promise<void> {
+  const hub = new Hub((s) => {
+    s.welcome();
+    void s.next(); // read the subscribe but never confirm
+  });
+  const conn = await openEventStream(streamDeps(hub), {
+    reconnect: { disabled: true },
+    subscribeTimeoutMs: 150,
+  });
+  let threw = false;
+  try {
+    await conn.subscribe(chatRoomChannel());
+  } catch {
+    threw = true;
+  }
+  assert("subscribe timeout: rejects when never confirmed", threw);
+  await conn.close();
+}
+
+async function doneAndErrOnCleanClose(): Promise<void> {
+  const hub = new Hub((s) => s.welcome());
+  const conn = await openEventStream(streamDeps(hub), { reconnect: { disabled: true } });
+  assert("clean close: err() undefined before close", conn.err() === undefined);
+  await conn.close();
+  await conn.done();
+  assert("clean close: err() undefined after caller close", conn.err() === undefined);
+}
+
+async function errAfterReconnectExhausted(): Promise<void> {
+  const hub = new Hub((s) => {
+    s.welcome();
+    s.close();
+  });
+  const conn = await openEventStream(streamDeps(hub), {
+    reconnect: { maxAttempts: 1, initialDelayMs: 10, maxDelayMs: 20 },
+  });
+  await Promise.race([conn.done(), sleep(4000)]);
+  assert("reconnect exhausted: err() is non-undefined", conn.err() !== undefined, String(conn.err()));
+  await conn.close();
+}
+
+async function onDropFiresWhenBufferFull(): Promise<void> {
+  let dropped = 0;
+  const ident = `{"channel":"ChatRoomChannel"}`;
+  const hub = new Hub((s) => {
+    s.welcome();
+    void (async () => {
+      const msg = await s.next();
+      s.confirm(msg.identifier as string);
+      for (let i = 0; i < 5; i++) s.pushEvent(ident, "chat_deleted", { room_id: i });
+    })();
+  });
+  const conn = await openEventStream(streamDeps(hub), {
+    reconnect: { disabled: true },
+    eventBuffer: 1,
+    onDrop: () => {
+      dropped++;
+    },
+  });
+  // Subscribe but never attach a listener — the buffer fills and overflow
+  // events must drop via onDrop.
+  await conn.subscribe(chatRoomChannel());
+  await waitUntil(() => dropped > 0);
+  assert("onDrop: fired >=1 when buffer full + no listener", dropped >= 1, `dropped=${dropped}`);
+  await conn.close();
+}
+
+async function stableConnectionResetsAttemptBudget(): Promise<void> {
+  let attempts = 0;
+  const hub = new Hub((s) => {
+    const n = ++attempts;
+    s.welcome();
+    void (async () => {
+      const msg = await s.next();
+      s.confirm(msg.identifier as string);
+      if (n <= 2) {
+        await sleep(80); // stay alive past the (shrunk) stability threshold
+        s.close();
+      }
+      // n>=3 stays open
+    })();
+  });
+  const conn = await openEventStream(streamDeps(hub), {
+    reconnect: { maxAttempts: 1, initialDelayMs: 10, maxDelayMs: 20 },
+    stableThresholdMs: 50,
+  });
+  await conn.subscribe(chatRoomChannel());
+  await waitUntil(() => attempts >= 3, 4000);
+  assert(
+    "stable reset: >=3 connections (stable conn reset the failure budget)",
+    attempts >= 3,
+    `attempts=${attempts}`,
+  );
+  await conn.close();
+}
+
+async function multipleSubsResubscribeAfterReconnect(): Promise<void> {
+  const identChat = `{"channel":"ChatRoomChannel"}`;
+  const identGroup = `{"channel":"GroupUpdatesChannel"}`;
+  let attempts = 0;
+  const hub = new Hub((s) => {
+    const n = ++attempts;
+    s.welcome();
+    void (async () => {
+      const seen = new Set<string>();
+      while (seen.size < 2) {
+        const msg = await s.next();
+        if (msg.command !== "subscribe") continue;
+        seen.add(msg.identifier as string);
+        s.confirm(msg.identifier as string);
+      }
+      if (n === 1) {
+        s.close();
+        return;
+      }
+      s.pushEvent(identChat, "chat_deleted", { room_id: 11 });
+      s.pushEvent(identGroup, "new_post", { group_id: 22 });
+    })();
+  });
+  const conn = await openEventStream(streamDeps(hub), { reconnect: FAST_RECONNECT });
+  const subChat = await conn.subscribe(chatRoomChannel());
+  const subGroup = await conn.subscribe(groupUpdatesChannel());
+  let chat = -1;
+  let group = -1;
+  subChat.onChatDeleted((ev) => {
+    chat = ev.roomId;
+  });
+  subGroup.onGroupUpdated((ev) => {
+    group = ev.groupId;
+  });
+  await waitUntil(() => chat === 11 && group === 22, 5000);
+  assert(
+    "resubscribe: both subs re-wired after reconnect (chat=11 group=22)",
+    chat === 11 && group === 22,
+    `chat=${chat} group=${group}`,
+  );
+  await conn.close();
+}
+
+// ---- Client-level: ws-token auth + dial does not leak Bearer ----------
+
+async function withHTTP(
+  handler: (path: string, auth: string) => { status: number; body: string },
+  fn: (baseURL: string, lastAuth: () => string) => Promise<void>,
+): Promise<void> {
+  let lastAuth = "";
+  const server: Server = createServer((req, res) => {
+    const u = new URL(req.url ?? "", "http://x");
+    if (u.pathname === "/v1/users/ws_token") lastAuth = req.headers["authorization"] ?? "";
+    const out = handler(u.pathname, req.headers["authorization"] ?? "");
+    res.writeHead(out.status, { "Content-Type": "application/json" }).end(out.body);
+  });
+  await new Promise<void>((r) => server.listen(0, r));
+  const baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  try {
+    await fn(baseURL, () => lastAuth);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+}
+
+async function clientWsTokenAuthAndNoBearerLeak(): Promise<void> {
+  await withHTTP(
+    () => ({ status: 200, body: JSON.stringify({ token: "ws-token-xyz" }) }),
+    async (baseURL) => {
+      let dialURL = "";
+      const factory = (url: string): WebSocketLike => {
+        dialURL = url;
+        const session = new Session();
+        const ws = new FakeWS(url, session, (s) => s.welcome());
+        ws.bind(session);
+        return ws;
+      };
+      const c = new Client({
+        baseURL,
+        eventStreamURL: "ws://cable.test",
+        webSocketFactory: factory,
+        retryPolicy: { maxAttempts: 0, baseDelay: 1, maxDelay: 1, retryOnPOST: false },
+      });
+      c.setTokens("SECRET-ACCESS-TOKEN", "REF");
+      const conn = await c.openEventStream({ reconnect: { disabled: true } });
+      assert("client ws: dial URL has token query", dialURL.includes("token=ws-token-xyz"), dialURL);
+      assert("client ws: dial URL has app_version query", dialURL.includes("app_version="), dialURL);
+      assert(
+        "client ws: dial URL does NOT leak the Bearer",
+        !dialURL.includes("SECRET-ACCESS-TOKEN"),
+        dialURL,
+      );
+      await conn.close();
+    },
+  );
+  // Separately assert the ws_token fetch was authenticated.
+  await withHTTP(
+    () => ({ status: 200, body: JSON.stringify({ token: "t" }) }),
+    async (baseURL, lastAuth) => {
+      const c = new Client({
+        baseURL,
+        webSocketFactory: (url) => {
+          const session = new Session();
+          const ws = new FakeWS(url, session, (s) => s.welcome());
+          ws.bind(session);
+          return ws;
+        },
+        retryPolicy: { maxAttempts: 0, baseDelay: 1, maxDelay: 1, retryOnPOST: false },
+      });
+      c.setTokens("BEARERTOK", "REF");
+      const conn = await c.openEventStream({ reconnect: { disabled: true } });
+      assert(
+        "client ws: ws_token request had Authorization: Bearer",
+        lastAuth() === "Bearer BEARERTOK",
+        lastAuth(),
+      );
+      await conn.close();
+    },
+  );
+}
+
+async function clientUnauthenticated401(): Promise<void> {
+  await withHTTP(
+    () => ({ status: 401, body: JSON.stringify({ error_code: -1, message: "unauthorized" }) }),
+    async (baseURL) => {
+      const c = new Client({
+        baseURL,
+        webSocketFactory: (url) => {
+          const session = new Session();
+          const ws = new FakeWS(url, session, (s) => s.welcome());
+          ws.bind(session);
+          return ws;
+        },
+        retryPolicy: { maxAttempts: 0, baseDelay: 1, maxDelay: 1, retryOnPOST: false },
+      });
+      let threw = false;
+      try {
+        await c.openEventStream({ reconnect: { disabled: true } });
+      } catch {
+        threw = true;
+      }
+      assert("client ws: unauthenticated open surfaces the 401", threw);
+    },
+  );
+}
+
+(async () => {
+  await subscribeAndReceiveEvent();
+  await rejectedSubscription();
+  await multipleChannels();
+  await reconnectAfterServerClose();
+  await unsubscribe();
+  await subscribeTimeout();
+  await doneAndErrOnCleanClose();
+  await errAfterReconnectExhausted();
+  await onDropFiresWhenBufferFull();
+  await stableConnectionResetsAttemptBudget();
+  await multipleSubsResubscribeAfterReconnect();
+  await clientWsTokenAuthAndNoBearerLeak();
+  await clientUnauthenticated401();
+  process.exit(failed === 0 ? 0 : 1);
+})().catch((e) => {
+  console.error("test crashed:", e);
+  process.exit(2);
+});

--- a/packages/typescript/tests/execute_raw.test.ts
+++ b/packages/typescript/tests/execute_raw.test.ts
@@ -1,0 +1,101 @@
+// executeRaw parity tests (PORTING.md §11.3). The raw escape hatch must
+// return the bytes + HTTP response while bypassing the typed JSON decode:
+//   - HTTP success      → { body, httpResponse, error: undefined }
+//   - HTTP 4xx/5xx      → { body, httpResponse, error: APIError } and
+//                          codeOf(error) still resolves the server code
+//   - bad JSON on 2xx   → still returns raw bytes, never throws
+//   - transport failure → { error } only
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { Client } from "../src/client";
+import { codeOf, APIError } from "../src/errors";
+
+let failed = 0;
+function assert(name: string, cond: boolean, detail = ""): void {
+  if (cond) console.log(`PASS ${name}`);
+  else {
+    failed++;
+    console.log(`FAIL ${name}${detail ? `\n  ${detail}` : ""}`);
+  }
+}
+
+async function withServer(
+  reply: { status: number; body: string },
+  fn: (baseURL: string) => Promise<void>,
+): Promise<void> {
+  const server: Server = createServer((_req, res) => {
+    res.writeHead(reply.status, { "Content-Type": "application/json" }).end(reply.body);
+  });
+  await new Promise<void>((r) => server.listen(0, r));
+  const baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  try {
+    await fn(baseURL);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+}
+
+const NO_RETRY = { maxAttempts: 0, baseDelay: 1, maxDelay: 1, retryOnPOST: false };
+const dec = (b?: Uint8Array) => (b ? new TextDecoder().decode(b) : "");
+
+async function successReturnsRawBytes(): Promise<void> {
+  const payload = JSON.stringify({ time: 1700000000, ip_address: "1.2.3.4" });
+  await withServer({ status: 200, body: payload }, async (baseURL) => {
+    const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+    const r = await c.executeRaw(() => c.usersAPI.getUserTimestampRaw());
+    assert("success: error undefined", r.error === undefined);
+    assert("success: httpResponse present + ok", r.httpResponse?.ok === true);
+    assert("success: raw bytes are the verbatim body", dec(r.body) === payload, dec(r.body));
+  });
+}
+
+async function badJsonOnSuccessDoesNotThrow(): Promise<void> {
+  await withServer({ status: 200, body: "this is <not> json" }, async (baseURL) => {
+    const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+    let crashed = false;
+    let body = "";
+    try {
+      const r = await c.executeRaw(() => c.usersAPI.getUserTimestampRaw());
+      body = dec(r.body);
+    } catch {
+      crashed = true;
+    }
+    assert("bad json on 2xx: never throws (decode bypassed)", !crashed);
+    assert("bad json on 2xx: raw bytes preserved", body === "this is <not> json", body);
+  });
+}
+
+async function httpErrorReturnsAPIErrorWithCode(): Promise<void> {
+  const errBody = JSON.stringify({ error_code: 7, message: "forbidden" });
+  await withServer({ status: 403, body: errBody }, async (baseURL) => {
+    const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+    const r = await c.executeRaw(() => c.usersAPI.getUserTimestampRaw());
+    assert("http error: error is APIError", r.error instanceof APIError);
+    assert("http error: httpResponse present", r.httpResponse?.status === 403, String(r.httpResponse?.status));
+    assert("http error: raw error body returned", dec(r.body) === errBody, dec(r.body));
+    assert("http error: codeOf(error) === 7", codeOf(r.error) === 7, String(codeOf(r.error)));
+  });
+}
+
+async function transportFailureReturnsErrorOnly(): Promise<void> {
+  // Unroutable port → fetch transport failure.
+  const c = new Client({ baseURL: "http://127.0.0.1:1", retryPolicy: NO_RETRY });
+  const r = await c.executeRaw(() => c.usersAPI.getUserTimestampRaw());
+  assert("transport failure: error present", r.error instanceof APIError);
+  assert("transport failure: no httpResponse", r.httpResponse === undefined);
+  assert("transport failure: no body", r.body === undefined);
+}
+
+(async () => {
+  await successReturnsRawBytes();
+  await badJsonOnSuccessDoesNotThrow();
+  await httpErrorReturnsAPIErrorWithCode();
+  await transportFailureReturnsErrorOnly();
+  process.exit(failed === 0 ? 0 : 1);
+})().catch((e) => {
+  console.error("test crashed:", e);
+  process.exit(2);
+});

--- a/packages/typescript/tests/upload.test.ts
+++ b/packages/typescript/tests/upload.test.ts
@@ -1,0 +1,521 @@
+// Upload parity tests (PORTING.md §8). Ports upload_test.go: filename
+// shaping, the s3/ canonical-name contract, content-type mapping,
+// per-category paths, the animated-GIF-stays-animated rule, login gating,
+// caps, and the presigned PUT never leaking the Bearer.
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { encode as jpegEncode } from "jpeg-js";
+import { GifWriter } from "omggif";
+import { PNG } from "pngjs";
+import { imageSize } from "image-size";
+
+import { Client } from "../src/client";
+import {
+  contentTypeFor,
+  formatYMD,
+  imageFilename,
+  randomFilenamePrefix,
+  thumbnailFilename,
+} from "../src/image";
+import { mediaURL } from "../src/config";
+import {
+  userAvatarUpload,
+  userPostUpload,
+  chatMessageUpload,
+  groupCreationIconUpload,
+  reportUpload,
+  videoCallSnapshotUpload,
+} from "../src/upload";
+
+let failed = 0;
+function assert(name: string, cond: boolean, detail = ""): void {
+  if (cond) {
+    console.log(`PASS ${name}`);
+  } else {
+    failed++;
+    console.log(`FAIL ${name}${detail ? `\n  ${detail}` : ""}`);
+  }
+}
+function assertEq<T>(name: string, got: T, want: T): void {
+  assert(name, got === want, `got=${String(got)} want=${String(want)}`);
+}
+
+// ---- image encoders (real bytes so image-size + the codecs work) ------
+
+function encodeJpeg(w: number, h: number): Uint8Array {
+  const data = new Uint8Array(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    data[i * 4] = i % 256;
+    data[i * 4 + 1] = (i * 3) % 256;
+    data[i * 4 + 2] = 200;
+    data[i * 4 + 3] = 255;
+  }
+  return new Uint8Array(jpegEncode({ width: w, height: h, data }, 80).data);
+}
+
+function encodePng(w: number, h: number): Uint8Array {
+  const png = new PNG({ width: w, height: h });
+  for (let i = 0; i < w * h; i++) {
+    png.data[i * 4] = i % 256;
+    png.data[i * 4 + 1] = (i * 5) % 256;
+    png.data[i * 4 + 2] = 120;
+    png.data[i * 4 + 3] = 255;
+  }
+  return new Uint8Array(PNG.sync.write(png));
+}
+
+function encodeGif(w: number, h: number, frames = 1): Uint8Array {
+  const buf = new Uint8Array(w * h * frames * 2 + 4096 + frames * 256 * 3);
+  const gw = new GifWriter(buf, w, h, { loop: 0 });
+  // omggif requires a power-of-two palette.
+  const palette = [0x000000, 0xffffff, 0xc80000, 0x00c800];
+  for (let f = 0; f < frames; f++) {
+    const idx = new Uint8Array(w * h);
+    for (let i = 0; i < w * h; i++) idx[i] = (i + f) % palette.length;
+    gw.addFrame(0, 0, w, h, idx, { palette, delay: 10, disposal: 0 });
+  }
+  return buf.slice(0, gw.end());
+}
+
+// ---- fake Yay! API + S3 server ----------------------------------------
+
+interface FakeState {
+  objects: Map<string, Uint8Array>;
+  contentTypes: Map<string, string>;
+  putAuth: string[];
+  imageNames: string[];
+  videoFileName: string;
+  presignedCalls: number;
+  failPresigned: boolean;
+  emptyPresigned: boolean;
+  putFails: boolean;
+}
+
+async function withFakeServer<T>(
+  init: Partial<FakeState>,
+  fn: (baseURL: string, st: FakeState) => Promise<T>,
+): Promise<T> {
+  const st: FakeState = {
+    objects: new Map(),
+    contentTypes: new Map(),
+    putAuth: [],
+    imageNames: [],
+    videoFileName: "",
+    presignedCalls: 0,
+    failPresigned: false,
+    emptyPresigned: false,
+    putFails: false,
+    ...init,
+  };
+  const server: Server = createServer((req, res) => {
+    const u = new URL(req.url ?? "", "http://x");
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      if (req.method === "GET" && u.pathname === "/v1/buckets/presigned_urls") {
+        st.presignedCalls++;
+        if (st.failPresigned) {
+          res.writeHead(500).end("presigned fail");
+          return;
+        }
+        const names = u.searchParams.getAll("file_names[]");
+        st.imageNames = names.slice();
+        const urls = st.emptyPresigned
+          ? []
+          : names.map((n) => ({ filename: `s3/${n}`, url: `${baseURL}/uploads/s3/${n}` }));
+        res.writeHead(200, { "Content-Type": "application/json" }).end(
+          JSON.stringify({ presigned_urls: urls }),
+        );
+        return;
+      }
+      if (req.method === "GET" && u.pathname === "/v1/users/presigned_url") {
+        const name = u.searchParams.get("video_file_name") ?? "";
+        st.videoFileName = name;
+        res.writeHead(200, { "Content-Type": "application/json" }).end(
+          JSON.stringify({ presigned_url: `${baseURL}/uploads/${name}` }),
+        );
+        return;
+      }
+      if (req.method === "PUT" && u.pathname.startsWith("/uploads/")) {
+        st.putAuth.push(req.headers["authorization"] ?? "");
+        if (st.putFails) {
+          res.writeHead(500).end("put fail");
+          return;
+        }
+        const key = u.pathname;
+        st.objects.set(key, new Uint8Array(Buffer.concat(chunks)));
+        st.contentTypes.set(key, req.headers["content-type"] ?? "");
+        res.writeHead(200).end();
+        return;
+      }
+      res.writeHead(404).end("unknown route");
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, r));
+  const baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  try {
+    return await fn(baseURL, st);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+}
+
+const NO_RETRY = { maxAttempts: 0, baseDelay: 1, maxDelay: 1, retryOnPOST: false };
+
+function loggedIn(baseURL: string, userID: number): Client {
+  const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+  c.setLoginIdentity("u@example.com", userID);
+  return c;
+}
+
+// ---- pure-function parity --------------------------------------------
+
+function pureTests(): void {
+  assertEq(
+    "imageFilename: full shape",
+    imageFilename("user/42/avatar", "ABC123", 1700000000000, 0, ".png", 200, 100),
+    "user/42/avatar/ABC123_1700000000000_0_size_200x100.png",
+  );
+  assertEq(
+    "imageFilename: no size suffix when 0",
+    imageFilename("user/42/avatar", "ABC123", 1700000000000, 2, ".jpeg", 0, 0),
+    "user/42/avatar/ABC123_1700000000000_2.jpeg",
+  );
+  assertEq(
+    "imageFilename: empty ext -> .jpg",
+    imageFilename("user/42/avatar", "ABC123", 1700000000000, 0, "", 10, 10),
+    "user/42/avatar/ABC123_1700000000000_0_size_10x10.jpg",
+  );
+  assertEq(
+    "thumbnailFilename: thumb_ prefix + orig size",
+    thumbnailFilename("user/42/avatar", "ABC123", 1700000000000, 0, ".jpeg", 800, 600),
+    "user/42/avatar/thumb_ABC123_1700000000000_0_size_800x600.jpeg",
+  );
+
+  for (const [fn, want] of [
+    ["a.png", "image/png"],
+    ["path/to/B.PNG", "image/png"],
+    ["a.GIF", "image/gif"],
+    ["a.jpg", "image/jpeg"],
+    ["a.JPG", "image/jpeg"],
+    ["a.mp4", "video/mp4"],
+    ["unknown", "image/jpeg"],
+    ["", "image/jpeg"],
+    ["weird.xyz", "image/jpeg"],
+  ] as const) {
+    assertEq(`contentTypeFor(${fn})`, contentTypeFor(fn), want);
+  }
+
+  assertEq(
+    "formatYMD: no zero padding",
+    formatYMD(new Date(Date.UTC(2026, 3, 9))),
+    "2026/4/9",
+  );
+  assertEq(
+    "formatYMD: double digits",
+    formatYMD(new Date(Date.UTC(2000, 0, 1))),
+    "2000/1/1",
+  );
+
+  assertEq(
+    "mediaURL: s3 prefix preserved",
+    mediaURL("s3/user/7360590/avatar/abc_123_0_size_251x251.jpeg"),
+    "https://cdn.yay.space/uploads/s3/user/7360590/avatar/abc_123_0_size_251x251.jpeg",
+  );
+  assertEq("mediaURL: leading slash trimmed", mediaURL("/s3/x.jpg"), "https://cdn.yay.space/uploads/s3/x.jpg");
+  assertEq("mediaURL: empty", mediaURL(""), "");
+
+  const allowed = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  let prefixOK = true;
+  for (let n = 1; n <= 32; n++) {
+    const got = randomFilenamePrefix(n);
+    if (got.length !== n || [...got].some((ch) => !allowed.includes(ch))) prefixOK = false;
+  }
+  assert("randomFilenamePrefix: length + alphabet", prefixOK);
+
+  const now = new Date(Date.UTC(2026, 3, 26, 12));
+  assertEq("category: userAvatar", userAvatarUpload(7360590).path(now), "user/7360590/avatar");
+  assertEq("category: userPost (date bucketed)", userPostUpload(7360590).path(now), "user/7360590/posts/2026/4/26");
+  assertEq(
+    "category: chatMessage",
+    chatMessageUpload(1, 2).path(now),
+    "chatroom/1/user/2/messages/2026/4/26",
+  );
+  assertEq("category: groupCreationIcon", groupCreationIconUpload().path(now), "group/create/icon/2026/4/26");
+  assertEq("category: report", reportUpload().path(now), "report/2026/4/26");
+  assertEq("category: videoCallSnapshot", videoCallSnapshotUpload().path(now), "video_call_snapshot/2026/4/26");
+  assertEq("category: report cap is 4", reportUpload().maxFiles(), 4);
+  assertEq("category: videoCallSnapshot has no thumb", videoCallSnapshotUpload().thumbnail()[2], false);
+}
+
+// ---- scenarios --------------------------------------------------------
+
+async function scenarioPostImagesHappyPath(): Promise<void> {
+  await withFakeServer({}, async (baseURL, st) => {
+    const c = loggedIn(baseURL, 7360590);
+    const png = encodePng(30, 40);
+    const gif = encodeGif(50, 50);
+    const jpg = encodeJpeg(60, 80);
+    const names = await c.uploadPostImages([
+      { filename: "selfie.png", body: png },
+      { filename: "sticker.gif", body: gif },
+      { filename: "photo.jpg", body: jpg },
+    ]);
+    assertEq("postImages: 3 names returned", names.length, 3);
+
+    const wantExt = [".png", ".gif", ".jpg"];
+    const wantCT = ["image/png", "image/gif", "image/jpeg"];
+    const wantSize = ["_size_30x40", "_size_50x50", "_size_60x80"];
+    const year = new Date().getUTCFullYear();
+    for (let i = 0; i < 3; i++) {
+      const name = names[i];
+      assert(`postImages[${i}] ext ${wantExt[i]}`, name.endsWith(wantExt[i]), name);
+      assert(
+        `postImages[${i}] s3/user/7360590/posts/<year>/ prefix`,
+        name.startsWith(`s3/user/7360590/posts/${year}/`),
+        name,
+      );
+      assert(`postImages[${i}] size suffix ${wantSize[i]}`, name.includes(wantSize[i]), name);
+      assertEq(`postImages[${i}] content-type`, st.contentTypes.get(`/uploads/${name}`), wantCT[i]);
+    }
+    let thumbCount = 0;
+    for (const [p, ct] of st.contentTypes) {
+      if (!p.includes("/thumb_")) continue;
+      thumbCount++;
+      if (p.endsWith(".gif")) assertEq("gif thumb content-type", ct, "image/gif");
+      else if (p.endsWith(".jpeg")) assertEq("jpeg thumb content-type", ct, "image/jpeg");
+    }
+    assertEq("postImages: 3 thumbnails uploaded", thumbCount, 3);
+    assertEq("postImages: 6 file_names[] (3 main + 3 thumb)", st.imageNames.length, 6);
+  });
+}
+
+async function scenarioAvatarHappyAndShape(): Promise<void> {
+  await withFakeServer({}, async (baseURL, st) => {
+    const c = loggedIn(baseURL, 1);
+    const name = await c.uploadAvatarImage({ filename: "x.png", body: encodePng(12, 13) });
+    assert(
+      "avatar: filename shape",
+      /^s3\/user\/1\/avatar\/[0-9A-Za-z]{16}_\d{13}_0_size_12x13\.png$/.test(name),
+      name,
+    );
+    assert("avatar: main object PUT", st.objects.has(`/uploads/${name}`));
+  });
+}
+
+async function scenarioRequiresLogin(): Promise<void> {
+  const c = new Client({ baseURL: "http://127.0.0.1:1" });
+  let threw = false;
+  try {
+    await c.uploadAvatarImage({ filename: "x.jpg", body: encodeJpeg(5, 5) });
+  } catch (e) {
+    threw = (e as Error).message.includes("not logged in");
+  }
+  assert("avatar without login: 'not logged in' error", threw);
+}
+
+async function scenarioUnknownExtFallsBackToJpeg(): Promise<void> {
+  await withFakeServer({}, async (baseURL, st) => {
+    const c = loggedIn(baseURL, 1);
+    for (const fn of ["noext", "weird.xyz"]) {
+      const name = await c.uploadAvatarImage({ filename: fn, body: encodeJpeg(5, 5) });
+      assert(`unknown ext (${fn}) -> .jpg`, name.endsWith(".jpg"), name);
+      assertEq(`unknown ext (${fn}) content-type`, st.contentTypes.get(`/uploads/${name}`), "image/jpeg");
+    }
+  });
+}
+
+async function scenarioEmptyAndOverflow(): Promise<void> {
+  const c = loggedIn("http://does-not-matter", 1);
+  let e1 = false;
+  try {
+    await c.uploadPostImages([]);
+  } catch {
+    e1 = true;
+  }
+  assert("postImages([]) rejects", e1);
+  const tooMany = Array.from({ length: 10 }, () => ({ filename: "x.jpg", body: encodeJpeg(2, 2) }));
+  let e2 = false;
+  try {
+    await c.uploadPostImages(tooMany);
+  } catch {
+    e2 = true;
+  }
+  assert("postImages(10) rejects (cap 9)", e2);
+  let e3 = false;
+  try {
+    await c.uploadReportImages(Array.from({ length: 5 }, () => ({ filename: "x.jpg", body: encodeJpeg(2, 2) })));
+  } catch {
+    e3 = true;
+  }
+  assert("reportImages(5) rejects (cap 4)", e3);
+}
+
+async function scenarioPutFailure(): Promise<void> {
+  await withFakeServer({ putFails: true }, async (baseURL) => {
+    const c = loggedIn(baseURL, 1);
+    let msg = "";
+    try {
+      await c.uploadAvatarImage({ filename: "a.png", body: encodePng(5, 5) });
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    assert("put failure: 'PUT 500' in message", msg.includes("PUT 500"), msg);
+  });
+}
+
+async function scenarioPresignedFailure(): Promise<void> {
+  await withFakeServer({ failPresigned: true }, async (baseURL) => {
+    const c = loggedIn(baseURL, 1);
+    let threw = false;
+    try {
+      await c.uploadAvatarImage({ filename: "a.png", body: encodePng(5, 5) });
+    } catch {
+      threw = true;
+    }
+    assert("presigned 500: surfaces error", threw);
+  });
+}
+
+async function scenarioEmptyPresigned(): Promise<void> {
+  await withFakeServer({ emptyPresigned: true }, async (baseURL) => {
+    const c = loggedIn(baseURL, 1);
+    let msg = "";
+    try {
+      await c.uploadAvatarImage({ filename: "x.png", body: encodePng(5, 5) });
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    assert("empty presigned: 'count mismatch'", msg.includes("count mismatch"), msg);
+  });
+}
+
+async function scenarioNonImage(): Promise<void> {
+  await withFakeServer({}, async (baseURL) => {
+    const c = loggedIn(baseURL, 1);
+    let msg = "";
+    try {
+      await c.uploadAvatarImage({ filename: "broken.jpg", body: new TextEncoder().encode("not an image at all") });
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    assert("non-image body: 'decode image' error", msg.includes("decode image"), msg);
+  });
+}
+
+async function scenarioVideoHappyAndNil(): Promise<void> {
+  await withFakeServer({}, async (baseURL, st) => {
+    const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+    const mp4 = new TextEncoder().encode("\x00\x00\x00 ftypisom--mp4-bytes--");
+    const name = await c.uploadVideo(mp4);
+    assert("video: .mp4 suffix", name.endsWith(".mp4"), name);
+    assertEq("video: content-type", st.contentTypes.get(`/uploads/${name}`), "video/mp4");
+    assertEq("video: server saw same filename", st.videoFileName, name);
+
+    let threw = false;
+    try {
+      await c.uploadVideo(null as unknown as Uint8Array);
+    } catch {
+      threw = true;
+    }
+    assert("video nil body: rejects", threw);
+  });
+}
+
+async function scenarioGifThumbStaysGif(): Promise<void> {
+  await withFakeServer({}, async (baseURL, st) => {
+    const c = loggedIn(baseURL, 1);
+    await c.uploadAvatarImage({ filename: "x.gif", body: encodeGif(800, 400, 3) });
+    assertEq("gif avatar: 2 file_names[] (main gif + gif thumb)", st.imageNames.length, 2);
+    let thumb: Uint8Array | undefined;
+    let thumbPath = "";
+    for (const [p, b] of st.objects) {
+      if (p.includes("/thumb_")) {
+        thumb = b;
+        thumbPath = p;
+        break;
+      }
+    }
+    assert("gif avatar: thumbnail PUT exists", thumb != null);
+    assert("gif thumb path ends .gif", thumbPath.endsWith(".gif"), thumbPath);
+    assertEq("gif thumb content-type", st.contentTypes.get(thumbPath), "image/gif");
+    if (thumb) {
+      const dim = imageSize(thumb);
+      assertEq("gif thumb format", dim.type, "gif");
+      assertEq("gif thumb width", dim.width, 200);
+      assertEq("gif thumb height", dim.height, 100);
+    }
+  });
+}
+
+async function scenarioJpegThumbDims(): Promise<void> {
+  await withFakeServer({}, async (baseURL, st) => {
+    const c = loggedIn(baseURL, 7);
+    await c.uploadAvatarImage({ filename: "me.jpg", body: encodeJpeg(800, 600) });
+    let thumb: Uint8Array | undefined;
+    for (const [p, b] of st.objects) {
+      if (p.includes("/thumb_")) {
+        thumb = b;
+        break;
+      }
+    }
+    assert("jpeg avatar: thumbnail PUT exists", thumb != null);
+    if (thumb) {
+      const dim = imageSize(thumb);
+      assertEq("jpeg thumb format", dim.type, "jpg");
+      assertEq("jpeg thumb width (fit 200x200)", dim.width, 200);
+      assertEq("jpeg thumb height (fit 200x200)", dim.height, 150);
+    }
+  });
+}
+
+async function scenarioVideoCallSnapshotSkipsThumb(): Promise<void> {
+  await withFakeServer({}, async (baseURL, st) => {
+    const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+    const name = await c.uploadVideoCallSnapshotImage({ filename: "snap.jpg", body: encodeJpeg(100, 100) });
+    assert("snapshot: name returned", name.length > 0);
+    assertEq("snapshot: only 1 file_names[] (no thumb)", st.imageNames.length, 1);
+    let anyThumb = false;
+    for (const p of st.contentTypes.keys()) if (p.includes("/thumb_")) anyThumb = true;
+    assert("snapshot: no thumbnail uploaded", !anyThumb);
+  });
+}
+
+async function scenarioNoBearerLeakOnPut(): Promise<void> {
+  await withFakeServer({}, async (baseURL, st) => {
+    const c = loggedIn(baseURL, 1);
+    c.setTokens("SECRET-ACCESS-TOKEN", "REF");
+    await c.uploadAvatarImage({ filename: "x.png", body: encodePng(5, 5) });
+    assert("PUT requests captured", st.putAuth.length > 0);
+    assert(
+      "no PUT carried Authorization (presigned URL signs via query)",
+      st.putAuth.every((a) => a === ""),
+      st.putAuth.join(","),
+    );
+  });
+}
+
+(async () => {
+  pureTests();
+  await scenarioPostImagesHappyPath();
+  await scenarioAvatarHappyAndShape();
+  await scenarioRequiresLogin();
+  await scenarioUnknownExtFallsBackToJpeg();
+  await scenarioEmptyAndOverflow();
+  await scenarioPutFailure();
+  await scenarioPresignedFailure();
+  await scenarioEmptyPresigned();
+  await scenarioNonImage();
+  await scenarioVideoHappyAndNil();
+  await scenarioGifThumbStaysGif();
+  await scenarioJpegThumbDims();
+  await scenarioVideoCallSnapshotSkipsThumb();
+  await scenarioNoBearerLeakOnPut();
+  process.exit(failed === 0 ? 0 : 1);
+})().catch((e) => {
+  console.error("test crashed:", e);
+  process.exit(2);
+});


### PR DESCRIPTION
## 概要

TS SDK の手書き層の残作業を実装。`upload.go` / `event_stream.go` / `events.go` を TS へ移植し、PORTING.md §8 / §10 / §11.3 の契約に準拠。

## 変更点

- **uploads (§8)** — `src/upload.ts` + `src/image.ts`：13 upload カテゴリ + `uploadVideo`。filename 生成 / s3 canonical 名 / animated GIF サムネ（アニメ維持）を `upload.go` と同値で移植。presigned PUT は生成 middleware を経由しない raw fetch で実行（Bearer 非漏洩）。画像処理は `jpeg-js` / `pngjs` / `omggif` / `image-size` を依存追加。
- **event stream (§10)** — `src/event_stream.ts` + `src/events.ts` + `src/channels.ts`：WebSocket multiplex、4 channel / 7 event、reconnect（jitter backoff・stable threshold・MaxAttempts）、OnDrop。WebSocket は `webSocketFactory` で注入可能（テストは hermetic、`ws` 依存なし）。
- **raw escape hatch (§11.3)** — `Client.executeRaw`：typed JSON decode をバイパスし `{ body, httpResponse, error }`。2xx は error なし、4xx/5xx は `APIError`（`codeOf` 可）、transport 失敗は error のみ。
- `Client` に upload 13 メソッド + `uploadVideo` + `openEventStream` + `executeRaw` を配線、`index.ts` で公開面を export。

## 検証

- `tsc --noEmit` / `npm run build` 通過
- `npm test` **168 PASS / 0 FAIL**（既存 + 新規 upload / event_stream / execute_raw を配線）

## スコープ外

生成物 `src/gen/` の再生成、Go / `packages/python/`、PORTING §1-3 は未変更。生成物再生成・統合・pointer 操作は統合担当が実施。