### PR TITLE
feat(py): yaylib Python ポート — 手書き層 + 47 シナリオ parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,14 @@ packages/**/node_modules
 packages/**/dist
 packages/**/*.tgz
 
+# Python
+packages/**/.venv
+packages/**/__pycache__
+packages/**/*.pyc
+packages/**/.pytest_cache
+packages/**/.tox
+packages/**/*.egg-info
+
 # Editors
 .idea/
 .vscode/

--- a/packages/python/pytest.ini
+++ b/packages/python/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::UserWarning

--- a/packages/python/tests/_raw_server.py
+++ b/packages/python/tests/_raw_server.py
@@ -1,0 +1,71 @@
+"""Minimal raw-socket HTTP/1.1 server for tests that need to drop a
+connection mid-exchange (simulating a post-refresh network failure).
+
+aiohttp's web server always completes a response, so the
+connection-level failure scenario from the Go reference
+(``TestTransport_401RefreshSucceedsButRetryNetworkErrorSurfacesError``,
+which hijacks and closes the TCP socket) needs a hand-rolled server.
+``Connection: close`` is sent on every response so each request is its
+own connection — no pipelining to parse.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Callable, Tuple
+
+# decide(path, method, body) -> ("respond", status, body_str) | ("drop",)
+Decider = Callable[[str, str, str], Tuple]
+
+
+@contextlib.asynccontextmanager
+async def serve_raw(decide: Decider):
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            header_blob = await reader.readuntil(b"\r\n\r\n")
+        except (asyncio.IncompleteReadError, asyncio.LimitOverrunError):
+            writer.close()
+            return
+        lines = header_blob.decode("latin1").split("\r\n")
+        method, path, _ = lines[0].split(" ", 2)
+        content_length = 0
+        for ln in lines[1:]:
+            if ln.lower().startswith("content-length:"):
+                content_length = int(ln.split(":", 1)[1].strip() or "0")
+        body = b""
+        if content_length:
+            body = await reader.readexactly(content_length)
+
+        action = decide(path, method, body.decode("utf-8", "replace"))
+        if action[0] == "drop":
+            # Abruptly close without a response → client sees a
+            # connection-level failure (aiohttp ClientError).
+            writer.transport.abort()
+            return
+
+        _, status, payload = action
+        data = payload.encode("utf-8")
+        head = (
+            f"HTTP/1.1 {status} X\r\n"
+            f"Content-Type: application/json\r\n"
+            f"Content-Length: {len(data)}\r\n"
+            f"Connection: close\r\n\r\n"
+        ).encode("latin1")
+        writer.write(head + data)
+        with contextlib.suppress(Exception):
+            await writer.drain()
+        writer.close()
+        with contextlib.suppress(Exception):
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        await server.start_serving()
+        try:
+            yield f"http://127.0.0.1:{port}"
+        finally:
+            server.close()
+            with contextlib.suppress(Exception):
+                await server.wait_closed()

--- a/packages/python/tests/_server.py
+++ b/packages/python/tests/_server.py
@@ -1,0 +1,45 @@
+"""In-process HTTP server for parity tests.
+
+Mirrors the Node ``createServer`` helper used by the TypeScript tests.
+The server is force-shut on teardown (connections cancelled) so a
+lingering keep-alive socket can't hang the test process.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Awaitable, Callable, Tuple
+
+from aiohttp import web
+
+# handler(path, method, body) -> (status, body, headers)
+Handler = Callable[[str, str, str], Tuple[int, str, dict]]
+
+
+@contextlib.asynccontextmanager
+async def serve(handler: Handler):
+    async def _dispatch(request: web.Request) -> web.Response:
+        body = await request.text()
+        result = handler(request.path_qs, request.method, body)
+        if len(result) == 3:
+            status, out_body, extra = result
+        else:
+            status, out_body = result
+            extra = {}
+        headers = {"Content-Type": "application/json"}
+        headers.update(extra or {})
+        return web.Response(status=status, text=out_body, headers=headers)
+
+    app = web.Application()
+    app.router.add_route("*", "/{tail:.*}", _dispatch)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        # cleanup() closes the listening socket AND drops live
+        # connections, so undici-style keep-alive lingering can't stall.
+        await runner.cleanup()

--- a/packages/python/tests/_server.py
+++ b/packages/python/tests/_server.py
@@ -8,19 +8,28 @@ lingering keep-alive socket can't hang the test process.
 from __future__ import annotations
 
 import contextlib
-from typing import Awaitable, Callable, Tuple
+import inspect
+from typing import Callable, Tuple
 
 from aiohttp import web
 
-# handler(path, method, body) -> (status, body, headers)
-Handler = Callable[[str, str, str], Tuple[int, str, dict]]
+# handler(path, method, body[, headers]) -> (status, body[, headers]).
+# A 4-arg handler additionally receives the request headers (CIMultiDict).
+Handler = Callable[..., Tuple]
 
 
 @contextlib.asynccontextmanager
 async def serve(handler: Handler):
+    wants_headers = len(inspect.signature(handler).parameters) >= 4
+
     async def _dispatch(request: web.Request) -> web.Response:
         body = await request.text()
-        result = handler(request.path_qs, request.method, body)
+        if wants_headers:
+            result = handler(
+                request.path_qs, request.method, body, request.headers
+            )
+        else:
+            result = handler(request.path_qs, request.method, body)
         if len(result) == 3:
             status, out_body, extra = result
         else:

--- a/packages/python/tests/_ws_server.py
+++ b/packages/python/tests/_ws_server.py
@@ -1,0 +1,119 @@
+"""In-process HTTP+WebSocket server for event-stream parity tests.
+
+Mirrors the Go reference's fakeServer / wsSession: a JSON
+``/v1/users/ws_token`` handler plus a WebSocket upgrade on every other
+path. ``on_connect`` (an async callable) drives behaviour per accepted
+socket. Connections are force-closed on teardown so a lingering socket
+can't hang the test process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Awaitable, Callable
+
+from aiohttp import WSMsgType, web
+
+
+class WSSession:
+    def __init__(self, ws: web.WebSocketResponse) -> None:
+        self.ws = ws
+        self.received: "asyncio.Queue[dict]" = asyncio.Queue()
+        self._closed = asyncio.Event()
+
+    async def _read_loop(self) -> None:
+        try:
+            async for msg in self.ws:
+                if msg.type == WSMsgType.TEXT:
+                    with contextlib.suppress(ValueError, TypeError):
+                        self.received.put_nowait(json.loads(msg.data))
+                elif msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSING,
+                                  WSMsgType.CLOSED, WSMsgType.ERROR):
+                    break
+        finally:
+            self._closed.set()
+
+    async def send_welcome(self) -> None:
+        await self.ws.send_str('{"type":"welcome","sid":"test-sid"}')
+
+    async def confirm(self, identifier: str) -> None:
+        await self.ws.send_str(
+            json.dumps(
+                {"identifier": identifier, "type": "confirm_subscription"}
+            )
+        )
+
+    async def reject(self, identifier: str) -> None:
+        await self.ws.send_str(
+            json.dumps(
+                {"identifier": identifier, "type": "reject_subscription"}
+            )
+        )
+
+    async def push_event(self, identifier: str, event: str, data) -> None:
+        inner = json.dumps({"event": event, "data": data})
+        await self.ws.send_str(
+            json.dumps({"identifier": identifier, "message": inner})
+        )
+
+    async def close(self) -> None:
+        with contextlib.suppress(Exception):
+            await self.ws.close()
+        self._closed.set()
+
+    async def idle(self) -> None:
+        """Block until the socket closes (the test-side analog of the Go
+        reference's ``<-s.ctx.Done()``)."""
+        await self._closed.wait()
+
+
+OnConnect = Callable[[WSSession], Awaitable[None]]
+
+
+@contextlib.asynccontextmanager
+async def serve_ws(on_connect: OnConnect):
+    open_sessions: "set[WSSession]" = set()
+
+    async def ws_token(_req: web.Request) -> web.Response:
+        return web.json_response({"token": "test-token"})
+
+    async def timestamp(_req: web.Request) -> web.Response:
+        # Benign response for the lazy X-Client-IP fetch so it doesn't
+        # add error noise during stream tests.
+        return web.json_response({"time": 0, "ip_address": "127.0.0.1"})
+
+    async def ws_handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        sess = WSSession(ws)
+        open_sessions.add(sess)
+        reader = asyncio.ensure_future(sess._read_loop())
+        try:
+            await on_connect(sess)
+        finally:
+            reader.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await reader
+            with contextlib.suppress(Exception):
+                await ws.close()
+            open_sessions.discard(sess)
+        return ws
+
+    app = web.Application()
+    app.router.add_get("/v1/users/ws_token", ws_token)
+    app.router.add_get("/v2/users/timestamp", timestamp)
+    app.router.add_route("GET", "/{tail:.*}", ws_handler)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        for s in list(open_sessions):
+            await s.close()
+        await runner.cleanup()

--- a/packages/python/tests/test_auth.py
+++ b/packages/python/tests/test_auth.py
@@ -1,0 +1,232 @@
+# login_with_email wrapper parity tests (PORTING.md §6).
+# Mirrors tests/auth.test.ts: cache hit / miss / no_cache / save failure /
+# file-store round trip.
+
+import json
+
+import pytest
+
+from yaylib.client import Client
+from yaylib.session import (
+    MemorySessionStore,
+    NoSessionError,
+    Session,
+    SessionSaveFailed,
+)
+from yaylib.session_file import FileSessionStore, new_session_store
+
+from ._server import serve
+
+
+async def test_fresh_login_persists(tmp_path):
+    login_hits = 0
+
+    def handler(path, method, body):
+        nonlocal login_hits
+        if path == "/v3/users/login_with_email":
+            login_hits += 1
+            parsed = json.loads(body or "{}")
+            if (
+                parsed.get("email") != "alice@example.com"
+                or parsed.get("password") != "p4ss"
+            ):
+                return 400, '{"error_code":-1}', {}
+            return (
+                200,
+                json.dumps(
+                    {
+                        "access_token": "ACC",
+                        "refresh_token": "REF",
+                        "user_id": 42,
+                    }
+                ),
+                {},
+            )
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        store = await new_session_store(str(tmp_path / "sessions.json"))
+        client = Client(base_url=base_url, session_store=store)
+        try:
+            res = await (
+                client.login_with_email()
+                .email("alice@example.com")
+                .password("p4ss")
+                .execute()
+            )
+            assert login_hits == 1
+            assert res.access_token == "ACC"
+            assert client.tokens.access == "ACC"
+            assert client.user_id == 42
+            persisted = await store.load("alice@example.com")
+            assert persisted.user_id == 42
+        finally:
+            await client.close()
+
+
+async def test_cache_hit_no_http():
+    login_hits = 0
+
+    def handler(path, method, body):
+        nonlocal login_hits
+        login_hits += 1
+        return 500, "{}", {}
+
+    async with serve(handler) as base_url:
+        store = MemorySessionStore()
+        await store.save(
+            Session(
+                email="bob@example.com",
+                user_id=99,
+                access_token="cached-acc",
+                refresh_token="cached-ref",
+                device_uuid="11111111-1111-1111-1111-111111111111",
+                updated_at="2024-01-01T00:00:00Z",
+            )
+        )
+        client = Client(base_url=base_url, session_store=store)
+        try:
+            res = await (
+                client.login_with_email()
+                .email("bob@example.com")
+                .password("ignored")
+                .execute()
+            )
+            assert login_hits == 0
+            assert client.tokens.access == "cached-acc"
+            assert client.user_id == 99
+            assert client.device_uuid == "11111111-1111-1111-1111-111111111111"
+            assert res.user_id == 99
+        finally:
+            await client.close()
+
+
+async def test_no_cache_bypass():
+    login_hits = 0
+
+    def handler(path, method, body):
+        nonlocal login_hits
+        if path == "/v3/users/login_with_email":
+            login_hits += 1
+            return (
+                200,
+                json.dumps(
+                    {
+                        "access_token": "FRESH",
+                        "refresh_token": "FRESH-R",
+                        "user_id": 7,
+                    }
+                ),
+                {},
+            )
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        store = MemorySessionStore()
+        await store.save(
+            Session(
+                email="carol@example.com",
+                user_id=1,
+                access_token="OLD",
+                refresh_token="OLD-R",
+                device_uuid="22222222-2222-2222-2222-222222222222",
+                updated_at="2024-01-01T00:00:00Z",
+            )
+        )
+        client = Client(base_url=base_url, session_store=store)
+        try:
+            res = await (
+                client.login_with_email()
+                .email("carol@example.com")
+                .password("p4ss")
+                .no_cache()
+                .execute()
+            )
+            assert login_hits == 1
+            assert client.tokens.access == "FRESH"
+            assert res.access_token == "FRESH"
+            persisted = await store.load("carol@example.com")
+            assert persisted.access_token == "FRESH"
+        finally:
+            await client.close()
+
+
+class _FailingStore(MemorySessionStore):
+    async def load(self, email):
+        raise NoSessionError(email)
+
+    async def save(self, session):
+        raise RuntimeError("disk full")
+
+
+async def test_save_failure_wraps_but_keeps_tokens():
+    def handler(path, method, body):
+        if path == "/v3/users/login_with_email":
+            return (
+                200,
+                json.dumps(
+                    {"access_token": "A", "refresh_token": "R", "user_id": 5}
+                ),
+                {},
+            )
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url, session_store=_FailingStore())
+        try:
+            with pytest.raises(SessionSaveFailed):
+                await (
+                    client.login_with_email()
+                    .email("dave@example.com")
+                    .password("p4ss")
+                    .execute()
+                )
+            assert client.tokens.access == "A"
+            assert client.user_id == 5
+        finally:
+            await client.close()
+
+
+async def test_file_store_round_trip(tmp_path):
+    login_hits = 0
+
+    def handler(path, method, body):
+        nonlocal login_hits
+        if path == "/v3/users/login_with_email":
+            login_hits += 1
+            return (
+                200,
+                json.dumps(
+                    {"access_token": "T", "refresh_token": "T-R", "user_id": 11}
+                ),
+                {},
+            )
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        path = str(tmp_path / "sessions.json")
+        client1 = Client(base_url=base_url, session_store=FileSessionStore(path))
+        try:
+            await (
+                client1.login_with_email()
+                .email("eve@example.com")
+                .password("p4ss")
+                .execute()
+            )
+            assert login_hits == 1
+        finally:
+            await client1.close()
+
+        client2 = Client(base_url=base_url, session_store=FileSessionStore(path))
+        try:
+            await (
+                client2.login_with_email()
+                .email("eve@example.com")
+                .password("p4ss")
+                .execute()
+            )
+            assert login_hits == 1  # cache hit, no second HTTP login
+            assert client2.tokens.access == "T"
+            assert client2.user_id == 11
+        finally:
+            await client2.close()

--- a/packages/python/tests/test_auth_refresh.py
+++ b/packages/python/tests/test_auth_refresh.py
@@ -1,0 +1,150 @@
+# PORTING.md §6.1 contract verification against an in-process server.
+# Mirrors tests/auth_refresh.test.ts: the three documented outcomes plus
+# the concurrency collapse.
+
+import asyncio
+import json
+
+import pytest
+
+from yaylib.client import Client
+from yaylib.errors import APIError
+
+from ._server import serve
+
+
+async def test_refresh_success():
+    oauth_hits = 0
+    timeline_hits = 0
+
+    def handler(path, method, body):
+        nonlocal oauth_hits, timeline_hits
+        if path == "/api/v1/oauth/token":
+            oauth_hits += 1
+            if "grant_type=refresh_token" not in body:
+                return 400, '{"error":"bad_grant"}', {}
+            return (
+                200,
+                json.dumps(
+                    {
+                        "access_token": "fresh-access",
+                        "refresh_token": "fresh-refresh",
+                        "user_id": 7,
+                    }
+                ),
+                {},
+            )
+        if "/v2/users/timestamp" in path:
+            timeline_hits += 1
+            if timeline_hits == 1:
+                return 401, '{"error_code":-1}', {}
+            return (
+                200,
+                json.dumps({"time": 1700000000, "ip_address": "203.0.113.5"}),
+                {},
+            )
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url)
+        client.set_tokens("stale-access", "stale-refresh")
+        try:
+            res = await client.users_api.get_user_timestamp()
+            assert res.time == 1700000000
+            assert oauth_hits == 1
+            assert timeline_hits == 2
+            assert client.tokens.access == "fresh-access"
+            assert client.tokens.refresh == "fresh-refresh"
+        finally:
+            await client.close()
+
+
+async def test_refresh_fails_surfaces_original_401():
+    def handler(path, method, body):
+        if path == "/api/v1/oauth/token":
+            return 401, '{"error_code":-100,"message":"refresh expired"}', {}
+        if "/v2/users/timestamp" in path:
+            return 401, '{"error_code":-1,"message":"unauthorized"}', {}
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url)
+        client.set_tokens("stale-access", "stale-refresh")
+        try:
+            with pytest.raises(APIError) as ei:
+                await client.users_api.get_user_timestamp()
+            assert ei.value.status == 401
+            assert client.tokens.access == "stale-access"
+        finally:
+            await client.close()
+
+
+async def test_no_refresh_token_skips_refresh():
+    oauth_hits = 0
+
+    def handler(path, method, body):
+        nonlocal oauth_hits
+        if path == "/api/v1/oauth/token":
+            oauth_hits += 1
+            return 200, "{}", {}
+        if "/v2/users/timestamp" in path:
+            return 401, '{"error_code":-1}', {}
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url)
+        client.set_tokens("only-access", "")
+        try:
+            with pytest.raises(APIError) as ei:
+                await client.users_api.get_user_timestamp()
+            assert ei.value.status == 401
+            assert oauth_hits == 0
+        finally:
+            await client.close()
+
+
+async def test_concurrent_401s_collapse_to_one_refresh():
+    oauth_hits = 0
+    timeline_hits = 0
+
+    def handler(path, method, body):
+        nonlocal oauth_hits, timeline_hits
+        if path == "/api/v1/oauth/token":
+            oauth_hits += 1
+            if "grant_type=refresh_token" not in body:
+                return 400, '{"error":"bad_grant"}', {}
+            return (
+                200,
+                json.dumps(
+                    {
+                        "access_token": "fresh",
+                        "refresh_token": "fresh-r",
+                        "user_id": 7,
+                    }
+                ),
+                {},
+            )
+        if "/v2/users/timestamp" in path:
+            timeline_hits += 1
+            if timeline_hits <= 3:
+                return 401, '{"error_code":-1}', {}
+            return (
+                200,
+                json.dumps({"time": 1700000001, "ip_address": "203.0.113.5"}),
+                {},
+            )
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url)
+        client.set_tokens("stale", "stale-r")
+        try:
+            results = await asyncio.gather(
+                client.users_api.get_user_timestamp(),
+                client.users_api.get_user_timestamp(),
+                client.users_api.get_user_timestamp(),
+            )
+            assert oauth_hits == 1
+            assert all(r.time == 1700000001 for r in results)
+        finally:
+            await client.close()

--- a/packages/python/tests/test_client_ip.py
+++ b/packages/python/tests/test_client_ip.py
@@ -1,0 +1,75 @@
+# Lazy X-Client-IP parity test (PORTING.md §12 + §15). Translated from
+# the Go reference's TestTransport_LazyFetchClientIPPopulatesHeader: the
+# first request goes out WITHOUT X-Client-IP (the fetch is async); the
+# background GET /v2/users/timestamp caches ip_address; the second
+# request carries it.
+
+import asyncio
+
+import pytest
+
+from yaylib.client import Client
+
+from ._server import serve
+
+FETCHED_IP = "203.0.113.7"
+
+
+async def test_lazy_fetch_client_ip_populates_header():
+    block_ips = []  # X-Client-IP seen on each /v1/users/1/block hit
+
+    def handler(path, method, body, headers):
+        if path.endswith("/v2/users/timestamp"):
+            return (
+                200,
+                '{"time":0,"ip_address":"%s"}' % FETCHED_IP,
+                {},
+            )
+        if path == "/v1/users/1/block":
+            block_ips.append(headers.get("X-Client-IP", ""))
+            return 200, "{}", {}
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url)
+        try:
+            # First request kicks off the lazy IP fetch in the
+            # background; the request itself goes out without the header.
+            await client.users_api.block_user(id=1)
+
+            deadline = asyncio.get_event_loop().time() + 2.0
+            while asyncio.get_event_loop().time() < deadline:
+                if client.client_ip == FETCHED_IP:
+                    break
+                await asyncio.sleep(0.02)
+            assert client.client_ip == FETCHED_IP
+
+            await client.users_api.block_user(id=1)
+
+            assert block_ips[0] == ""  # async fetch — first goes bare
+            assert block_ips[1] == FETCHED_IP
+        finally:
+            await client.close()
+
+
+async def test_close_cancels_pending_background_work():
+    # PORTING.md §3: close() cancels background work owned by the Client.
+    # Simulate a still-running lazy fetch with a long-lived task and
+    # assert close() cancels it (and returns promptly, not in ~100s).
+    client = Client(base_url="http://127.0.0.1:1")
+
+    async def _never():
+        await asyncio.sleep(100)
+
+    task = asyncio.ensure_future(_never())
+    client._bg_tasks.add(task)
+    task.add_done_callback(client._bg_tasks.discard)
+
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    await client.close()
+    elapsed = loop.time() - start
+
+    assert task.cancelled()
+    assert client._bg_tasks == set()
+    assert elapsed < 5  # did not wait the 100s sleep out

--- a/packages/python/tests/test_errors.py
+++ b/packages/python/tests/test_errors.py
@@ -1,0 +1,111 @@
+# Error-layer parity (PORTING.md §9 + §15). Translated from the Go
+# reference's auth_test.go: 2FA-required surfaces as the typed code, and
+# a session-store load failure returns the error WITHOUT any HTTP
+# (rate-limit protection). Plus the §9 robustness invariants for
+# code_of / error_response_of / raw-body retention.
+
+import json
+
+import pytest
+
+from yaylib.client import Client
+from yaylib.errors import APIError, code_of, error_response_of
+from yaylib.session import MemorySessionStore, NoSessionError
+
+from ._server import serve
+
+# ErrCodeRequired2FA from the Yay! error catalog (error_codes.go).
+ERR_CODE_REQUIRED_2FA = -31
+
+
+async def test_2fa_required_surfaces_typed_code():
+    def handler(path, method, body):
+        if path.endswith("/login_with_email"):
+            return (
+                401,
+                json.dumps(
+                    {
+                        "error_code": ERR_CODE_REQUIRED_2FA,
+                        "message": "2FA required",
+                    }
+                ),
+                {},
+            )
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url)
+        try:
+            with pytest.raises(APIError) as ei:
+                await (
+                    client.login_with_email()
+                    .email("u@example.com")
+                    .password("pw")
+                    .execute()
+                )
+            err = ei.value
+            assert code_of(err) == ERR_CODE_REQUIRED_2FA
+            parsed = error_response_of(err)
+            assert parsed is not None
+            assert parsed.message == "2FA required"
+            # Tokens must not be set on a 2FA-required response.
+            assert client.tokens.access == ""
+        finally:
+            await client.close()
+
+
+class _LoadErrorStore(MemorySessionStore):
+    async def load(self, email):
+        raise RuntimeError("corrupt JSON")
+
+
+async def test_login_store_load_error_returns_without_http():
+    hits = 0
+
+    def handler(path, method, body):
+        nonlocal hits
+        if path.endswith("/login_with_email"):
+            hits += 1
+        return 500, "{}", {}
+
+    async with serve(handler) as base_url:
+        client = Client(
+            base_url=base_url, session_store=_LoadErrorStore()
+        )
+        try:
+            with pytest.raises(RuntimeError, match="corrupt JSON"):
+                await (
+                    client.login_with_email()
+                    .email("foo@example.com")
+                    .password("pw")
+                    .execute()
+                )
+            # A non-NoSessionError load failure must NOT fall through to
+            # an HTTP login (rate-limit protection, PORTING.md §15).
+            assert hits == 0
+        finally:
+            await client.close()
+
+
+def test_code_of_and_error_response_of_on_non_api_error():
+    # Never raise; return the zero-ish code / None for unrecognized
+    # errors (PORTING.md §9).
+    assert code_of(ValueError("nope")) == 0
+    assert code_of(None) == 0
+    assert error_response_of(ValueError("nope")) is None
+    assert error_response_of(None) is None
+
+
+def test_api_error_retains_raw_body():
+    # An APIError stays usable for raw-body access; it is not collapsed
+    # into ErrorResponse only (PORTING.md §9).
+    err = APIError(status=400, reason="Bad Request")
+    err.body = json.dumps(
+        {"error_code": -1, "message": "bad", "ban_until": 123}
+    )
+    assert code_of(err) == -1
+    parsed = error_response_of(err)
+    assert parsed.message == "bad"
+    assert parsed.ban_until == 123
+    # Raw body still readable directly.
+    assert "error_code" in err.body

--- a/packages/python/tests/test_event_stream.py
+++ b/packages/python/tests/test_event_stream.py
@@ -1,0 +1,403 @@
+# Event-stream parity (PORTING.md §10 / §10.1 / §15). Scenarios
+# translated from the Go reference's event_stream_test.go — the
+# behaviour, not the Go channel mechanics.
+
+import asyncio
+
+import pytest
+from aiohttp import web
+
+from yaylib import event_stream as es
+from yaylib.client import Client
+from yaylib.event_stream import (
+    ChatDeletedEvent,
+    EventStreamOptions,
+    GroupUpdatedEvent,
+    ReconnectPolicy,
+    TotalChatRequestEvent,
+    chat_room_channel,
+    group_updates_channel,
+)
+
+from ._ws_server import serve_ws
+
+
+def _client(http_url: str) -> Client:
+    ws_url = http_url.replace("http://", "ws://", 1)
+    c = Client(base_url=http_url, event_stream_url=ws_url)
+    c.set_tokens("stub", "")  # skip auth-refresh path
+    return c
+
+
+_DISABLED = EventStreamOptions(reconnect=ReconnectPolicy(disabled=True))
+
+
+async def test_subscribe_and_receive_event():
+    async def on_connect(s):
+        await s.send_welcome()
+        msg = await s.received.get()
+        assert msg["command"] == "subscribe"
+        await s.confirm(msg["identifier"])
+        await s.push_event(msg["identifier"], "chat_deleted", {"room_id": 123})
+        await s.idle()
+
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(_DISABLED) as stream:
+                sub = await stream.subscribe(chat_room_channel())
+                ev = await sub.next_event(timeout=2)
+                assert isinstance(ev, ChatDeletedEvent)
+                assert ev.room_id == 123
+        finally:
+            await client.close()
+
+
+async def test_rejected_subscription():
+    async def on_connect(s):
+        await s.send_welcome()
+        msg = await s.received.get()
+        await s.reject(msg["identifier"])
+        await s.idle()
+
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(_DISABLED) as stream:
+                with pytest.raises(Exception):
+                    await stream.subscribe(chat_room_channel())
+        finally:
+            await client.close()
+
+
+async def test_multiple_channels():
+    async def on_connect(s):
+        await s.send_welcome()
+        for _ in range(2):
+            msg = await s.received.get()
+            await s.confirm(msg["identifier"])
+        await s.push_event(
+            '{"channel":"ChatRoomChannel"}',
+            "total_chat_request",
+            {"total_count": 7},
+        )
+        await s.push_event(
+            '{"channel":"GroupUpdatesChannel"}',
+            "new_post",
+            {"group_id": 42},
+        )
+        await s.idle()
+
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(_DISABLED) as stream:
+                sub1 = await stream.subscribe(chat_room_channel())
+                sub2 = await stream.subscribe(group_updates_channel())
+                e1 = await sub1.next_event(timeout=3)
+                e2 = await sub2.next_event(timeout=3)
+                assert isinstance(e1, TotalChatRequestEvent)
+                assert e1.total_count == 7
+                assert isinstance(e2, GroupUpdatedEvent)
+                assert e2.group_id == 42
+        finally:
+            await client.close()
+
+
+async def test_reconnect_after_server_close_resubscribes():
+    attempts = 0
+
+    async def on_connect(s):
+        nonlocal attempts
+        attempts += 1
+        n = attempts
+        await s.send_welcome()
+        msg = await s.received.get()
+        assert msg["command"] == "subscribe"
+        await s.confirm(msg["identifier"])
+        if n == 1:
+            await s.close()  # drop right after confirm
+            return
+        await s.push_event(msg["identifier"], "chat_deleted", {"room_id": 999})
+        await s.idle()
+
+    opts = EventStreamOptions(
+        reconnect=ReconnectPolicy(initial_delay=0.05, max_delay=0.2)
+    )
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(opts) as stream:
+                sub = await stream.subscribe(chat_room_channel())
+                ev = await sub.next_event(timeout=3)
+                assert isinstance(ev, ChatDeletedEvent)
+                assert ev.room_id == 999
+                assert attempts >= 2
+        finally:
+            await client.close()
+
+
+async def test_unsubscribe_closes_events():
+    got_unsub = asyncio.Event()
+
+    async def on_connect(s):
+        await s.send_welcome()
+        msg = await s.received.get()
+        await s.confirm(msg["identifier"])
+        while True:
+            nxt = await s.received.get()
+            if nxt["command"] == "unsubscribe":
+                got_unsub.set()
+                return
+
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(_DISABLED) as stream:
+                sub = await stream.subscribe(chat_room_channel())
+                await sub.unsubscribe()
+                await asyncio.wait_for(got_unsub.wait(), timeout=2)
+                with pytest.raises(ConnectionError):
+                    await sub.next_event(timeout=1)
+        finally:
+            await client.close()
+
+
+async def test_subscribe_timeout():
+    async def on_connect(s):
+        await s.send_welcome()
+        await s.received.get()  # never confirm
+        await s.idle()
+
+    opts = EventStreamOptions(
+        reconnect=ReconnectPolicy(disabled=True), subscribe_timeout=0.2
+    )
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(opts) as stream:
+                with pytest.raises(ConnectionError, match="timed out"):
+                    await stream.subscribe(chat_room_channel())
+        finally:
+            await client.close()
+
+
+async def test_done_and_err_on_clean_close():
+    async def on_connect(s):
+        await s.send_welcome()
+        await s.idle()
+
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            stream = await client.open_event_stream(_DISABLED)
+            assert stream.err() is None
+            await stream.close()
+            await asyncio.wait_for(stream.wait_done(), timeout=2)
+            assert stream.err() is None  # clean, caller-initiated
+        finally:
+            await client.close()
+
+
+async def test_err_after_reconnect_exhausted():
+    async def on_connect(s):
+        await s.send_welcome()
+        await s.close()  # drop immediately
+
+    opts = EventStreamOptions(
+        reconnect=ReconnectPolicy(
+            max_attempts=1, initial_delay=0.01, max_delay=0.02
+        )
+    )
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            stream = await client.open_event_stream(opts)
+            await asyncio.wait_for(stream.wait_done(), timeout=3)
+            assert stream.err() is not None
+        finally:
+            await client.close()
+
+
+async def test_on_drop_fires_when_buffer_full():
+    release = asyncio.Event()
+
+    async def on_connect(s):
+        await s.send_welcome()
+        msg = await s.received.get()
+        await s.confirm(msg["identifier"])
+        await release.wait()
+        for i in range(5):
+            await s.push_event(
+                msg["identifier"], "chat_deleted", {"room_id": i}
+            )
+        await s.idle()
+
+    dropped = 0
+
+    def on_drop(_ev):
+        nonlocal dropped
+        dropped += 1
+
+    opts = EventStreamOptions(
+        reconnect=ReconnectPolicy(disabled=True),
+        event_buffer=1,
+        on_drop=on_drop,
+    )
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(opts) as stream:
+                await stream.subscribe(chat_room_channel())
+                release.set()  # burst — we never consume the buffer
+                for _ in range(200):
+                    if dropped > 0:
+                        break
+                    await asyncio.sleep(0.01)
+                assert dropped >= 1
+        finally:
+            await client.close()
+
+
+async def test_decorator_handler_idiom():
+    async def on_connect(s):
+        await s.send_welcome()
+        msg = await s.received.get()
+        await s.confirm(msg["identifier"])
+        await s.push_event(msg["identifier"], "chat_deleted", {"room_id": 55})
+        await s.idle()
+
+    seen = asyncio.Queue()
+
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(_DISABLED) as stream:
+                sub = await stream.subscribe(chat_room_channel())
+
+                @sub.on_chat_deleted
+                def _h(ev):
+                    seen.put_nowait(ev)
+
+                ev = await asyncio.wait_for(seen.get(), timeout=2)
+                assert isinstance(ev, ChatDeletedEvent)
+                assert ev.room_id == 55
+        finally:
+            await client.close()
+
+
+async def test_multiple_subs_resubscribe_after_reconnect():
+    attempts = 0
+    ident_chat = '{"channel":"ChatRoomChannel"}'
+    ident_group = '{"channel":"GroupUpdatesChannel"}'
+
+    async def on_connect(s):
+        nonlocal attempts
+        attempts += 1
+        n = attempts
+        await s.send_welcome()
+        seen = set()
+        while len(seen) < 2:
+            msg = await s.received.get()
+            if msg.get("command") != "subscribe":
+                continue
+            seen.add(msg["identifier"])
+            await s.confirm(msg["identifier"])
+        assert ident_chat in seen and ident_group in seen
+        if n == 1:
+            await s.close()
+            return
+        await s.push_event(ident_chat, "chat_deleted", {"room_id": 11})
+        await s.push_event(ident_group, "new_post", {"group_id": 22})
+        await s.idle()
+
+    opts = EventStreamOptions(
+        reconnect=ReconnectPolicy(initial_delay=0.02, max_delay=0.05)
+    )
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(opts) as stream:
+                sub_chat = await stream.subscribe(chat_room_channel())
+                sub_group = await stream.subscribe(group_updates_channel())
+                e1 = await sub_chat.next_event(timeout=4)
+                e2 = await sub_group.next_event(timeout=4)
+                assert isinstance(e1, ChatDeletedEvent) and e1.room_id == 11
+                assert isinstance(e2, GroupUpdatedEvent) and e2.group_id == 22
+                assert attempts >= 2
+        finally:
+            await client.close()
+
+
+async def test_stable_connection_resets_attempt_budget(monkeypatch):
+    # Shrink the stability threshold so the test can cross it quickly.
+    monkeypatch.setattr(es, "reconnect_stable_threshold", 0.05)
+    attempts = 0
+
+    async def on_connect(s):
+        nonlocal attempts
+        attempts += 1
+        n = attempts
+        await s.send_welcome()
+        msg = await s.received.get()
+        await s.confirm(msg["identifier"])
+        if n <= 2:
+            # Stay alive past the (shrunk) threshold, then drop. Without
+            # the time-based reset, MaxAttempts=1 would exhaust after the
+            # 2nd connection — only the reset lets a 3rd dial happen.
+            await asyncio.sleep(0.08)
+            await s.close()
+            return
+        await s.idle()
+
+    opts = EventStreamOptions(
+        reconnect=ReconnectPolicy(
+            max_attempts=1, initial_delay=0.01, max_delay=0.02
+        )
+    )
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(opts) as stream:
+                await stream.subscribe(chat_room_channel())
+                for _ in range(200):
+                    if attempts >= 3:
+                        break
+                    await asyncio.sleep(0.01)
+                assert attempts >= 3
+        finally:
+            await client.close()
+
+
+async def test_ws_dial_does_not_leak_bearer():
+    captured = {}
+
+    async def ws_token(_req):
+        return web.json_response({"token": "stub"})
+
+    async def upgrade(request):
+        captured["auth"] = request.headers.get("Authorization", "")
+        return web.Response(status=400, text="no upgrade in this test")
+
+    app = web.Application()
+    app.router.add_get("/v1/users/ws_token", ws_token)
+    app.router.add_get("/v2/users/timestamp", lambda r: web.json_response(
+        {"time": 0, "ip_address": "127.0.0.1"}
+    ))
+    app.router.add_route("GET", "/{tail:.*}", upgrade)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    try:
+        client = _client(f"http://127.0.0.1:{port}")
+        client.set_tokens("SECRET-ACCESS-TOKEN", "REF")
+        try:
+            with pytest.raises(Exception):
+                await client.open_event_stream(_DISABLED)
+            assert captured.get("auth", "") == ""
+        finally:
+            await client.close()
+    finally:
+        await runner.cleanup()

--- a/packages/python/tests/test_headers.py
+++ b/packages/python/tests/test_headers.py
@@ -1,0 +1,87 @@
+# Required-header injection parity (PORTING.md §12 + §15). Translated
+# from the Go reference's TestTransport_InjectsRequiredHeaders and
+# TestTransport_OAuthEndpointUsesBasicAuth — the scenarios, not the Go
+# net/http mechanics.
+
+import base64
+import json
+
+from yaylib._config import DEFAULT_API_KEY
+from yaylib.client import Client
+
+from ._server import serve
+
+_REQUIRED = [
+    "User-Agent",
+    "X-App-Version",
+    "X-Device-Info",
+    "X-Device-UUID",
+    "X-Connection-Type",
+    "X-Connection-Speed",
+    "Accept-Language",
+    "X-Timestamp",
+]
+
+
+async def test_injects_required_headers_with_bearer():
+    captured = {}
+
+    def handler(path, method, body, headers):
+        captured.update(headers)
+        return 200, json.dumps({"time": 0, "ip_address": "1.2.3.4"}), {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url)
+        client.set_tokens("ACC", "REF")
+        try:
+            # get_user_timestamp is the /v2/users/timestamp path, so it
+            # carries the full header set without spawning a lazy-IP
+            # companion request — exactly one request to inspect.
+            await client.users_api.get_user_timestamp()
+        finally:
+            await client.close()
+
+    for h in _REQUIRED:
+        assert captured.get(h), f"missing required header {h}"
+    # Non-OAuth endpoint → Bearer.
+    assert captured.get("Authorization") == "Bearer ACC"
+    # PORTING.md §12 wire-significant literals.
+    assert captured.get("X-Connection-Speed") == "0 kbps"
+
+
+async def test_oauth_endpoint_uses_basic_auth():
+    # The /api/v1/oauth/token call is reachable through the 401
+    # auto-refresh path; capture the Authorization scheme the server
+    # actually sees there.
+    oauth_auth = {}
+
+    def handler(path, method, body, headers):
+        if path == "/api/v1/oauth/token":
+            oauth_auth["value"] = headers.get("Authorization", "")
+            return (
+                200,
+                json.dumps(
+                    {"access_token": "new-a", "refresh_token": "new-r"}
+                ),
+                {},
+            )
+        if path.endswith("/v2/users/timestamp"):
+            # 401 once → triggers refresh → retry succeeds.
+            if "first" not in oauth_auth:
+                oauth_auth["first"] = True
+                return 401, '{"error_code":-1}', {}
+            return 200, json.dumps({"time": 0, "ip_address": "1.2.3.4"}), {}
+        return 404, "", {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url)
+        client.set_tokens("stale", "stale-r")
+        try:
+            await client.users_api.get_user_timestamp()
+        finally:
+            await client.close()
+
+    got = oauth_auth.get("value", "")
+    assert got.startswith("Basic ")
+    expected = base64.b64encode(DEFAULT_API_KEY.encode("utf-8")).decode("ascii")
+    assert got == f"Basic {expected}"

--- a/packages/python/tests/test_refresh_retry_neterror.py
+++ b/packages/python/tests/test_refresh_retry_neterror.py
@@ -1,0 +1,58 @@
+# PORTING.md §6.1 case 3 / §15: refresh succeeds but the post-refresh
+# retry hits a connection-level failure. The caller MUST see the network
+# error, NOT a stale 401 (restoring the 401 would mislead them into
+# re-auth when the real problem is the network). Tokens stay rotated.
+#
+# Translated from the Go reference's
+# TestTransport_401RefreshSucceedsButRetryNetworkErrorSurfacesError.
+
+import json
+
+import pytest
+
+from yaylib.client import Client
+from yaylib.errors import APIError
+from yaylib.retry import RetryPolicy
+
+from ._raw_server import serve_raw
+
+
+async def test_refresh_ok_retry_neterror_surfaces_error_not_stale_401():
+    data_attempts = 0
+
+    def decide(path, method, body):
+        if "/api/v1/oauth/token" in path:
+            return (
+                "respond",
+                200,
+                json.dumps(
+                    {"access_token": "NEW_ACC", "refresh_token": "NEW_REF"}
+                ),
+            )
+        nonlocal data_attempts
+        data_attempts += 1
+        if data_attempts == 1:
+            return ("respond", 401, '{"error_code":-1}')
+        # Post-refresh retry: drop the connection.
+        return ("drop",)
+
+    async with serve_raw(decide) as base_url:
+        # Zero-value retry policy (mirrors Go's RetryPolicy{}) so the
+        # 401-refresh replay path is isolated from transient retry.
+        client = Client(
+            base_url=base_url,
+            retry_policy=RetryPolicy(
+                max_attempts=0, base_delay=0.0, max_delay=0.0
+            ),
+        )
+        client.set_tokens("STALE", "REF")
+        try:
+            with pytest.raises(APIError) as ei:
+                await client.users_api.get_user_timestamp()
+            # The surfaced error is the network failure, NOT a 401.
+            assert ei.value.status != 401
+            # Tokens were still rotated by the successful refresh.
+            assert client.tokens.access == "NEW_ACC"
+            assert client.tokens.refresh == "NEW_REF"
+        finally:
+            await client.close()

--- a/packages/python/tests/test_retry.py
+++ b/packages/python/tests/test_retry.py
@@ -1,0 +1,172 @@
+# RetryPolicy parity tests (PORTING.md §13). Mirrors tests/retry.test.ts:
+# 429 retries everywhere, 5xx retries only on safe methods (or POST when
+# opted in), body retry_in honored, max-attempts cap, zero-value
+# disables retry entirely.
+
+import json
+import time
+
+import pytest
+
+from yaylib.client import Client
+from yaylib.errors import APIError
+from yaylib.retry import RetryPolicy
+
+from ._server import serve
+
+# Tight backoff so tests stay snappy (seconds).
+FAST = RetryPolicy(
+    max_attempts=3, base_delay=0.001, max_delay=0.005, retry_on_post=False
+)
+
+
+async def test_get_5xx_retries_until_success():
+    hits = 0
+
+    def handler(path, method, body):
+        nonlocal hits
+        hits += 1
+        if hits < 3:
+            return 503, '{"error":"transient"}', {}
+        return 200, json.dumps({"time": 1700000000, "ip_address": "1.2.3.4"}), {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url, retry_policy=FAST)
+        try:
+            res = await client.users_api.get_user_timestamp()
+            assert res.time == 1700000000
+            assert hits == 3
+        finally:
+            await client.close()
+
+
+async def test_post_5xx_not_retried_by_default():
+    hits = 0
+
+    def handler(path, method, body):
+        nonlocal hits
+        hits += 1
+        return 503, '{"error":"transient"}', {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url, retry_policy=FAST)
+        try:
+            with pytest.raises(APIError):
+                await client.users_api.block_user(id=1)
+            assert hits == 1
+        finally:
+            await client.close()
+
+
+async def test_post_5xx_retries_when_opted_in():
+    hits = 0
+
+    def handler(path, method, body):
+        nonlocal hits
+        hits += 1
+        if hits < 2:
+            return 503, '{"error":"transient"}', {}
+        return 200, '{"success":true}', {}
+
+    policy = RetryPolicy(
+        max_attempts=3, base_delay=0.001, max_delay=0.005, retry_on_post=True
+    )
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url, retry_policy=policy)
+        try:
+            try:
+                await client.users_api.block_user(id=1)
+            except APIError:
+                pass
+            assert hits == 2
+        finally:
+            await client.close()
+
+
+async def test_429_retries_on_post_even_without_opt_in():
+    hits = 0
+
+    def handler(path, method, body):
+        nonlocal hits
+        hits += 1
+        if hits < 2:
+            return 429, '{"error":"rate_limited"}', {}
+        return 200, '{"success":true}', {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url, retry_policy=FAST)
+        try:
+            try:
+                await client.users_api.block_user(id=1)
+            except APIError:
+                pass
+            assert hits == 2
+        finally:
+            await client.close()
+
+
+async def test_retry_in_body_honored():
+    hits = 0
+    first_at = 0.0
+    second_at = 0.0
+
+    def handler(path, method, body):
+        nonlocal hits, first_at, second_at
+        hits += 1
+        now = time.monotonic()
+        if hits == 1:
+            first_at = now
+            return 503, json.dumps({"error": "wait", "retry_in": 0.05}), {}
+        second_at = now
+        return 200, json.dumps({"time": 1700000000, "ip_address": "1.2.3.4"}), {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url, retry_policy=FAST)
+        try:
+            res = await client.users_api.get_user_timestamp()
+            assert res.time == 1700000000
+            # base/max delay are <= 5ms; honoring retry_in (~50ms) is the
+            # only way the gap clears 30ms.
+            assert (second_at - first_at) >= 0.03
+        finally:
+            await client.close()
+
+
+async def test_max_attempts_reached_surfaces_last():
+    hits = 0
+
+    def handler(path, method, body):
+        nonlocal hits
+        hits += 1
+        return 503, '{"error":"perma"}', {}
+
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url, retry_policy=FAST)
+        try:
+            with pytest.raises(APIError) as ei:
+                await client.users_api.get_user_timestamp()
+            assert hits == 3
+            assert ei.value.status == 503
+        finally:
+            await client.close()
+
+
+async def test_zero_policy_disables_retry():
+    hits = 0
+
+    def handler(path, method, body):
+        nonlocal hits
+        hits += 1
+        return 503, '{"error":"perma"}', {}
+
+    policy = RetryPolicy(
+        max_attempts=0, base_delay=0.001, max_delay=0.001, retry_on_post=False
+    )
+    async with serve(handler) as base_url:
+        client = Client(base_url=base_url, retry_policy=policy)
+        try:
+            with pytest.raises(APIError):
+                await client.users_api.get_user_timestamp()
+            assert hits == 1
+        finally:
+            await client.close()

--- a/packages/python/tests/test_retry.py
+++ b/packages/python/tests/test_retry.py
@@ -45,6 +45,9 @@ async def test_post_5xx_not_retried_by_default():
 
     def handler(path, method, body):
         nonlocal hits
+        if path.endswith("/v2/users/timestamp"):
+            # Lazy X-Client-IP fetch (PORTING.md §12) — benign, uncounted.
+            return 200, '{"time":0,"ip_address":"1.2.3.4"}', {}
         hits += 1
         return 503, '{"error":"transient"}', {}
 
@@ -63,6 +66,8 @@ async def test_post_5xx_retries_when_opted_in():
 
     def handler(path, method, body):
         nonlocal hits
+        if path.endswith("/v2/users/timestamp"):
+            return 200, '{"time":0,"ip_address":"1.2.3.4"}', {}
         hits += 1
         if hits < 2:
             return 503, '{"error":"transient"}', {}
@@ -88,6 +93,8 @@ async def test_429_retries_on_post_even_without_opt_in():
 
     def handler(path, method, body):
         nonlocal hits
+        if path.endswith("/v2/users/timestamp"):
+            return 200, '{"time":0,"ip_address":"1.2.3.4"}', {}
         hits += 1
         if hits < 2:
             return 429, '{"error":"rate_limited"}', {}

--- a/packages/python/tests/test_session_file.py
+++ b/packages/python/tests/test_session_file.py
@@ -1,0 +1,90 @@
+# FileSessionStore round-trip / atomicity / concurrency parity tests.
+# Mirrors the contract in PORTING.md §5 + §5.1 and tests/session_file.test.ts.
+
+import asyncio
+import json
+import os
+import stat
+import sys
+
+import pytest
+
+from yaylib.session import NoSessionError, Session
+from yaylib.session_file import FileSessionStore, new_session_store
+
+
+def make_session(email: str, user_id: int) -> Session:
+    return Session(
+        email=email,
+        user_id=user_id,
+        access_token=f"access-{user_id}",
+        refresh_token=f"refresh-{user_id}",
+        device_uuid=f"00000000-0000-0000-0000-{user_id:012d}",
+        updated_at="",
+    )
+
+
+async def test_roundtrip(tmp_path):
+    path = str(tmp_path / "sessions.json")
+    store = await new_session_store(path)
+    await store.save(make_session("a@example.com", 1))
+    loaded = await store.load("a@example.com")
+    assert loaded.user_id == 1
+    assert loaded.access_token == "access-1"
+    assert loaded.device_uuid == "00000000-0000-0000-0000-000000000001"
+    assert loaded.updated_at != ""  # auto-populated
+
+
+async def test_load_missing_raises(tmp_path):
+    store = await new_session_store(str(tmp_path / "sessions.json"))
+    with pytest.raises(NoSessionError):
+        await store.load("ghost@example.com")
+
+
+async def test_delete_idempotent(tmp_path):
+    store = await new_session_store(str(tmp_path / "sessions.json"))
+    # No-op even when the file doesn't exist yet.
+    await store.delete("ghost@example.com")
+    await store.save(make_session("real@example.com", 7))
+    await store.delete("real@example.com")
+    with pytest.raises(NoSessionError):
+        await store.load("real@example.com")
+    # Second delete on the now-empty record is still a no-op.
+    await store.delete("real@example.com")
+
+
+async def test_multiple_sessions(tmp_path):
+    path = str(tmp_path / "sessions.json")
+    store = await new_session_store(path)
+    await store.save(make_session("a@example.com", 1))
+    await store.save(make_session("b@example.com", 2))
+    await store.save(make_session("c@example.com", 3))
+    assert (await store.load("a@example.com")).user_id == 1
+    assert (await store.load("b@example.com")).user_id == 2
+    assert (await store.load("c@example.com")).user_id == 3
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert len(data["sessions"]) == 3
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX perms only")
+async def test_file_permissions(tmp_path):
+    path = str(tmp_path / "sessions.json")
+    store = await new_session_store(path)
+    await store.save(make_session("perm@example.com", 9))
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == 0o600
+
+
+async def test_concurrent_writes(tmp_path):
+    path = str(tmp_path / "sessions.json")
+    store = FileSessionStore(path)
+    # 10 concurrent saves under distinct emails. The asyncio lock inside
+    # FileSessionStore serializes the read-modify-write cycles, so all 10
+    # records MUST be present in the final file.
+    await asyncio.gather(
+        *(store.save(make_session(f"u{i}@example.com", i + 1)) for i in range(10))
+    )
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert len(data["sessions"]) == 10

--- a/packages/python/tests/test_signing.py
+++ b/packages/python/tests/test_signing.py
@@ -1,0 +1,45 @@
+# Golden-vector parity with PORTING.md §7.1 — same inputs as the Go
+# reference's signing_test.go / tests/signing.test.ts and the documented
+# vectors. A drift in any of the three outputs means the formula changed
+# (encoding, key choice, message body, trailing whitespace) and the
+# Go / TS / Python ports are no longer byte-compatible.
+
+from yaylib._config import (
+    DEFAULT_API_KEY,
+    DEFAULT_API_VERSION_KEY,
+    DEFAULT_API_VERSION_NAME,
+)
+from yaylib.signing import (
+    generate_signed_info_at,
+    generate_signed_version,
+    generate_x_jwt,
+)
+
+
+def test_signed_info_golden_vector():
+    got = generate_signed_info_at(
+        api_key=DEFAULT_API_KEY,
+        device_uuid="00000000-0000-0000-0000-000000000000",
+        timestamp=1700000000,
+    )
+    assert got.timestamp == 1700000000
+    assert got.value == "253b7ca3e67590204034a73326d2be87"
+
+
+def test_signed_version_golden_vector():
+    got = generate_signed_version(
+        api_version_key=DEFAULT_API_VERSION_KEY,
+        api_version_name=DEFAULT_API_VERSION_NAME,
+    )
+    assert got == "zyKEqdZqaEqJjSRItHvchU9HmgWHNLtn02sWXwzQ4iQ="
+
+
+def test_x_jwt_golden_vector():
+    got = generate_x_jwt(
+        api_version_key=DEFAULT_API_VERSION_KEY, now=1700000000
+    )
+    assert got == (
+        "eyJhbGciOiJIUzI1NiJ9."
+        "eyJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MTcwMDAwMDAwNX0."
+        "-UYjGTM53-Uwe8tNGjBf4ZLx644_zUEK8fpW1w16KfA"
+    )

--- a/packages/python/yaylib/_config.py
+++ b/packages/python/yaylib/_config.py
@@ -1,0 +1,75 @@
+# Embedded wire constants. PORTING.md §3.1 fixes the defaults so a
+# freshly-constructed Client speaks to the Yay! servers without any
+# explicit option. Each constant is overridable via the corresponding
+# Client kwarg.
+#
+# This module is hand-written (the generated layer owns ``configuration.py``;
+# the underscore prefix keeps the two from colliding on import).
+
+from __future__ import annotations
+
+DEFAULT_API_KEY = (
+    "ccd59ee269c01511ba763467045c115779fcae3050238a252f1bd1a4b65cfec6"
+)
+
+# HS256 key used by signed_version and X-Jwt.
+DEFAULT_API_VERSION_KEY = "34c8c1cdf29b46a492e8ec58e6db37ec"
+
+# Value sent as X-App-Version and embedded in signed_version.
+DEFAULT_API_VERSION_NAME = "4.26"
+
+# Build version embedded in X-Device-Info.
+DEFAULT_APP_VERSION = "4.26.1"
+
+DEFAULT_DEVICE_TYPE = "android"
+DEFAULT_DEVICE_OS = "11"
+DEFAULT_DEVICE_DENSITY = "3.5"
+DEFAULT_DEVICE_SCREEN = "1440x2960"
+DEFAULT_DEVICE_MODEL = "Galaxy S9"
+
+DEFAULT_CONNECTION_TYPE = "wifi"
+DEFAULT_CONNECTION_SPEED = "0 kbps"
+DEFAULT_ACCEPT_LANGUAGE = "ja"
+
+DEFAULT_BASE_URL = "https://api.yay.space"
+DEFAULT_EVENT_STREAM_URL = "wss://cable.yay.space"
+MEDIA_CDN_BASE = "https://cdn.yay.space/uploads"
+
+# Wire pepper concatenated after APIKey + DeviceUUID + timestamp before
+# MD5-hashing for signed_info.
+SIGNED_INFO_SHARED_KEY = "yayZ1"
+
+# Platform identifier prepended to APIVersionName inside the
+# signed_version HMAC payload. Hard-coded; deviating risks per-platform
+# allowlist rejection.
+SIGNED_VERSION_PLATFORM = "yay_android"
+
+
+def build_user_agent(
+    *,
+    device_type: str,
+    device_os: str,
+    device_density: str,
+    device_screen: str,
+    device_model: str,
+) -> str:
+    return (
+        f"{device_type} {device_os} "
+        f"({device_density}x {device_screen} {device_model})"
+    )
+
+
+def build_device_info(app_version: str, user_agent: str) -> str:
+    return f"yay {app_version} {user_agent}"
+
+
+def media_url(filename: str) -> str:
+    """Public CDN URL for a filename returned by any ``upload_*`` method.
+
+    Prefer this over reading ``profile_icon`` / ``cover_image`` /
+    ``attachment_url`` off API responses, which can carry a legacy
+    prefix that no longer resolves.
+    """
+    if not filename:
+        return ""
+    return f"{MEDIA_CDN_BASE}/{filename.lstrip('/')}"

--- a/packages/python/yaylib/auth.py
+++ b/packages/python/yaylib/auth.py
@@ -1,0 +1,146 @@
+# PORTING.md §6: login_with_email is the ONLY wrapped auth endpoint —
+# it is the cache boundary, so "log in or use the cached session" is one
+# call. Other auth-flow body endpoints (create_user, edit_user,
+# login_with_sns, oauth token / refresh) stay as plain calls on the
+# generated API classes; wrapping each would multiply surface without
+# changing behaviour.
+
+from __future__ import annotations
+
+from typing import Optional
+
+from yaylib.errors import as_api_error
+from yaylib.models.login_email_user_request import LoginEmailUserRequest
+from yaylib.models.login_user_response import LoginUserResponse
+from yaylib.session import NoSessionError, Session, SessionSaveFailed
+
+
+class LoginWithEmailBuilder:
+    """Chain-setter form mirroring the Go reference. The generated layer
+    accepts only a single ``login_email_user_request`` body; this builder
+    lets callers set each field and auto-fills api_key / uuid from the
+    client.
+    """
+
+    def __init__(self, client) -> None:
+        self._client = client
+        self._email: Optional[str] = None
+        self._password: Optional[str] = None
+        self._api_key: Optional[str] = None
+        self._uuid: Optional[str] = None
+        self._two_fa_code: Optional[str] = None
+        self._bypass_cache = False
+
+    def email(self, v: str) -> "LoginWithEmailBuilder":
+        self._email = v
+        return self
+
+    def password(self, v: str) -> "LoginWithEmailBuilder":
+        self._password = v
+        return self
+
+    def api_key(self, v: str) -> "LoginWithEmailBuilder":
+        """Override the API key for this single login call."""
+        self._api_key = v
+        return self
+
+    def uuid(self, v: str) -> "LoginWithEmailBuilder":
+        """Override the device UUID for this single login call."""
+        self._uuid = v
+        return self
+
+    def two_fa_code(self, v: str) -> "LoginWithEmailBuilder":
+        self._two_fa_code = v
+        return self
+
+    def no_cache(self) -> "LoginWithEmailBuilder":
+        """Force a fresh HTTP login, bypassing any cached session."""
+        self._bypass_cache = True
+        return self
+
+    async def execute(self) -> LoginUserResponse:
+        return await _execute_login(self)
+
+
+def login_with_email(client) -> LoginWithEmailBuilder:
+    return LoginWithEmailBuilder(client)
+
+
+def _synthesize_login_response(session: Session) -> LoginUserResponse:
+    # Same shape regardless of cache hit vs. miss. Fields the server
+    # returns but the cache doesn't carry default to None.
+    return LoginUserResponse(
+        access_token=session.access_token,
+        refresh_token=session.refresh_token,
+        user_id=session.user_id,
+    )
+
+
+def _activate_cached_session(client, session: Session) -> None:
+    client.set_tokens(session.access_token, session.refresh_token)
+    if session.device_uuid:
+        client.set_device_uuid(session.device_uuid)
+    client.set_login_identity(session.email, session.user_id)
+
+
+async def _execute_login(b: LoginWithEmailBuilder) -> LoginUserResponse:
+    client = b._client
+    if not b._email or not b._password:
+        raise ValueError(
+            "yaylib: login_with_email requires email and password"
+        )
+
+    # Cache lookup — only with a session store configured and no
+    # .no_cache() opt-out.
+    if client.session_store is not None and not b._bypass_cache:
+        try:
+            cached = await client.session_store.load(b._email)
+        except NoSessionError:
+            cached = None  # cache miss → fall through to HTTP login
+        # Any other error (rate-limit, disk failure) propagates: the
+        # caller must not silently drop it on the wire-bound load path.
+        if cached is not None:
+            _activate_cached_session(client, cached)
+            return _synthesize_login_response(cached)
+
+    body = LoginEmailUserRequest(
+        api_key=b._api_key or client.api_key,
+        email=b._email,
+        password=b._password,
+        uuid=b._uuid or client.device_uuid,
+        two_f_a_code=b._two_fa_code,
+    )
+
+    try:
+        resp = await client.users_api.login_with_email(
+            login_email_user_request=body
+        )
+    except Exception as err:  # noqa: BLE001
+        raise as_api_error(err)
+
+    access = resp.access_token or ""
+    refresh = resp.refresh_token or ""
+    user_id = resp.user_id or 0
+    client.set_tokens(access, refresh)
+    client.set_login_identity(b._email, user_id)
+
+    if client.session_store is not None:
+        session = Session(
+            email=b._email,
+            user_id=user_id,
+            access_token=access,
+            refresh_token=refresh,
+            device_uuid=client.device_uuid,
+            updated_at="",
+        )
+        try:
+            await client.session_store.save(session)
+        except SessionSaveFailed:
+            raise
+        except Exception as err:  # noqa: BLE001
+            # PORTING.md §5: persist failure here surfaces as
+            # SessionSaveFailed, but the tokens are already active so the
+            # caller can choose to proceed.
+            raise SessionSaveFailed(err)
+
+    return resp

--- a/packages/python/yaylib/client.py
+++ b/packages/python/yaylib/client.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import uuid as _uuid
@@ -142,6 +143,7 @@ class Client:
         self._client_ip = ""
         self._client_ip_fetching = False
         self._bg_tasks: "set[asyncio.Task]" = set()
+        self._event_streams: set = set()
         self._refresh_inflight: Optional["asyncio.Future[bool]"] = None
 
         transport = Transport(
@@ -236,9 +238,29 @@ class Client:
     async def __aexit__(self, exc_type, exc, tb) -> None:
         await self.close()
 
+    def open_event_stream(self, opts=None):
+        """Open a multiplexed real-time event stream (PORTING.md §10).
+
+        Usable both as an async context manager and as a coroutine::
+
+            async with client.open_event_stream() as stream:
+                sub = await stream.subscribe(chat_room_channel())
+
+            stream = await client.open_event_stream(opts)
+            ...
+            await stream.close()
+        """
+        from yaylib.event_stream import _OpenEventStreamCM
+
+        return _OpenEventStreamCM(self, opts)
+
     async def close(self) -> None:
-        # PORTING.md §3: cancel background work owned by the Client (the
-        # lazy X-Client-IP fetch; open event streams land here later).
+        # PORTING.md §3: cancel background work owned by the Client — the
+        # lazy X-Client-IP fetch and every open event stream.
+        for stream in list(self._event_streams):
+            with contextlib.suppress(Exception):
+                await stream.close()
+        self._event_streams.clear()
         tasks = list(self._bg_tasks)
         for task in tasks:
             task.cancel()

--- a/packages/python/yaylib/client.py
+++ b/packages/python/yaylib/client.py
@@ -140,6 +140,8 @@ class Client:
         self._user_id = 0
         self._current_email = ""
         self._client_ip = ""
+        self._client_ip_fetching = False
+        self._bg_tasks: "set[asyncio.Task]" = set()
         self._refresh_inflight: Optional["asyncio.Future[bool]"] = None
 
         transport = Transport(
@@ -157,6 +159,7 @@ class Client:
             ),
             refresh=self._try_refresh,
             policy=self.retry_policy,
+            on_response=self._maybe_fetch_client_ip,
         )
         self._transport = transport
         config = Configuration(host=self.base_url)
@@ -234,7 +237,48 @@ class Client:
         await self.close()
 
     async def close(self) -> None:
+        # PORTING.md §3: cancel background work owned by the Client (the
+        # lazy X-Client-IP fetch; open event streams land here later).
+        tasks = list(self._bg_tasks)
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        self._bg_tasks.clear()
         await self._transport.close()
+
+    # ---- lazy X-Client-IP (PORTING.md §12) ----
+
+    def _maybe_fetch_client_ip(self) -> None:
+        """Single-flight: no-op when the IP is already known or a fetch
+        is in flight; otherwise spawn a background fetch. On failure the
+        field is left empty and the next request retries.
+        """
+        if self._client_ip or self._client_ip_fetching:
+            return
+        self._client_ip_fetching = True
+        task = asyncio.ensure_future(self._fetch_client_ip())
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)
+
+    async def _fetch_client_ip(self) -> None:
+        try:
+            resp = await asyncio.wait_for(
+                self.users_api.get_user_timestamp(), timeout=30
+            )
+            ip = getattr(resp, "ip_address", "") or ""
+            if ip:
+                self._client_ip = ip
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            # Leave the field empty; the next request retries the fetch.
+            pass
+        finally:
+            self._client_ip_fetching = False
 
     # ---- auth wrapper (PORTING.md §6) ----
 

--- a/packages/python/yaylib/client.py
+++ b/packages/python/yaylib/client.py
@@ -1,0 +1,336 @@
+# PORTING.md §2 / §3: Client is the single entry point. Every operation
+# is reachable via the per-tag API instances attached to the client
+# (``client.users_api.get_user(...)`` etc.); they all share one
+# ApiClient so the headers / refresh / retry transport is applied
+# uniformly. A flat promotion layer (PORTING.md §2) is generated in a
+# later step — for now the per-service handles are the stable surface,
+# matching the TypeScript port's ``client.usersAPI`` form.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid as _uuid
+from typing import Optional
+from urllib.parse import urlencode
+
+from yaylib.api.activities_api import ActivitiesApi
+from yaylib.api.apps_api import AppsApi
+from yaylib.api.auth_api import AuthApi
+from yaylib.api.buckets_api import BucketsApi
+from yaylib.api.calls_api import CallsApi
+from yaylib.api.chat_rooms_api import ChatRoomsApi
+from yaylib.api.conversations_api import ConversationsApi
+from yaylib.api.email_verification_urls_api import EmailVerificationUrlsApi
+from yaylib.api.games_api import GamesApi
+from yaylib.api.genres_api import GenresApi
+from yaylib.api.gifts_api import GiftsApi
+from yaylib.api.group_mute_api import GroupMuteApi
+from yaylib.api.groups_api import GroupsApi
+from yaylib.api.hidden_api import HiddenApi
+from yaylib.api.moderation_api import ModerationApi
+from yaylib.api.notification_settings_api import NotificationSettingsApi
+from yaylib.api.pinned_api import PinnedApi
+from yaylib.api.posts_api import PostsApi
+from yaylib.api.received_gifts_api import ReceivedGiftsApi
+from yaylib.api.sticker_packs_api import StickerPacksApi
+from yaylib.api.surveys_api import SurveysApi
+from yaylib.api.threads_api import ThreadsApi
+from yaylib.api.users_api import UsersApi
+from yaylib.api_client import ApiClient
+from yaylib.configuration import Configuration
+
+from yaylib._config import (
+    DEFAULT_ACCEPT_LANGUAGE,
+    DEFAULT_API_KEY,
+    DEFAULT_API_VERSION_KEY,
+    DEFAULT_API_VERSION_NAME,
+    DEFAULT_APP_VERSION,
+    DEFAULT_BASE_URL,
+    DEFAULT_CONNECTION_SPEED,
+    DEFAULT_CONNECTION_TYPE,
+    DEFAULT_DEVICE_DENSITY,
+    DEFAULT_DEVICE_MODEL,
+    DEFAULT_DEVICE_OS,
+    DEFAULT_DEVICE_SCREEN,
+    DEFAULT_DEVICE_TYPE,
+    DEFAULT_EVENT_STREAM_URL,
+    build_device_info,
+    build_user_agent,
+)
+from yaylib.retry import DEFAULT_RETRY_POLICY, RetryPolicy
+from yaylib.session import Session, SessionStore
+from yaylib.tokens import Tokens, empty_tokens
+from yaylib.transport import Transport, TransportContext
+
+_logger = logging.getLogger("yaylib")
+
+
+def new_uuid_v4() -> str:
+    """Canonical 8-4-4-4-12 hex UUID v4 from the OS CSPRNG. PORTING.md
+    §14: a failure of the randomness primitive MUST raise — never
+    degrade to a weak fallback (``uuid.uuid4`` is backed by os.urandom
+    and raises on failure).
+    """
+    return str(_uuid.uuid4())
+
+
+class _WrappedApiClient(ApiClient):
+    """ApiClient whose HTTP layer is our Transport. The generated
+    ``__init__`` builds an aiohttp session eagerly (and so requires a
+    running loop); we bypass it so Client stays synchronously
+    constructible.
+    """
+
+    def __init__(self, configuration: Configuration, transport: Transport):
+        self.configuration = configuration
+        self.rest_client = transport
+        # No default User-Agent: the transport composes and injects the
+        # Yay!-required one (PORTING.md §3.1). A non-empty default here
+        # would win via set-if-absent and pin the wrong value.
+        self.default_headers = {}
+        self.cookie = None
+        self.client_side_validation = configuration.client_side_validation
+
+
+class Client:
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        event_stream_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        api_version_key: Optional[str] = None,
+        api_version_name: Optional[str] = None,
+        app_version: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        device_info: Optional[str] = None,
+        device_uuid: Optional[str] = None,
+        connection_type: Optional[str] = None,
+        connection_speed: Optional[str] = None,
+        accept_language: Optional[str] = None,
+        session_store: Optional[SessionStore] = None,
+        retry_policy: Optional[RetryPolicy] = None,
+    ) -> None:
+        self.base_url = base_url or DEFAULT_BASE_URL
+        self.event_stream_url = event_stream_url or DEFAULT_EVENT_STREAM_URL
+        self.api_key = api_key or DEFAULT_API_KEY
+        self.api_version_key = api_version_key or DEFAULT_API_VERSION_KEY
+        self.api_version_name = api_version_name or DEFAULT_API_VERSION_NAME
+        self.app_version = app_version or DEFAULT_APP_VERSION
+        self.user_agent = user_agent or build_user_agent(
+            device_type=DEFAULT_DEVICE_TYPE,
+            device_os=DEFAULT_DEVICE_OS,
+            device_density=DEFAULT_DEVICE_DENSITY,
+            device_screen=DEFAULT_DEVICE_SCREEN,
+            device_model=DEFAULT_DEVICE_MODEL,
+        )
+        self.device_info = device_info or build_device_info(
+            self.app_version, self.user_agent
+        )
+        self._device_uuid = device_uuid or new_uuid_v4()
+        self.connection_type = connection_type or DEFAULT_CONNECTION_TYPE
+        self.connection_speed = connection_speed or DEFAULT_CONNECTION_SPEED
+        self.accept_language = accept_language or DEFAULT_ACCEPT_LANGUAGE
+        self.session_store = session_store
+        self.retry_policy = retry_policy or DEFAULT_RETRY_POLICY
+
+        self._tokens: Tokens = empty_tokens()
+        self._user_id = 0
+        self._current_email = ""
+        self._client_ip = ""
+        self._refresh_inflight: Optional["asyncio.Future[bool]"] = None
+
+        transport = Transport(
+            ctx=TransportContext(
+                user_agent=self.user_agent,
+                app_version=self.api_version_name,
+                device_info=self.device_info,
+                device_uuid=self._device_uuid,
+                connection_type=self.connection_type,
+                connection_speed=self.connection_speed,
+                accept_language=self.accept_language,
+                api_key=self.api_key,
+                client_ip=lambda: self._client_ip,
+                access_token=lambda: self._tokens.access,
+            ),
+            refresh=self._try_refresh,
+            policy=self.retry_policy,
+        )
+        self._transport = transport
+        config = Configuration(host=self.base_url)
+        api_client = _WrappedApiClient(config, transport)
+        self._api_client = api_client
+
+        self.activities_api = ActivitiesApi(api_client)
+        self.apps_api = AppsApi(api_client)
+        self.auth_api = AuthApi(api_client)
+        self.buckets_api = BucketsApi(api_client)
+        self.calls_api = CallsApi(api_client)
+        self.chat_rooms_api = ChatRoomsApi(api_client)
+        self.conversations_api = ConversationsApi(api_client)
+        self.email_verification_urls_api = EmailVerificationUrlsApi(api_client)
+        self.games_api = GamesApi(api_client)
+        self.genres_api = GenresApi(api_client)
+        self.gifts_api = GiftsApi(api_client)
+        self.group_mute_api = GroupMuteApi(api_client)
+        self.groups_api = GroupsApi(api_client)
+        self.hidden_api = HiddenApi(api_client)
+        self.moderation_api = ModerationApi(api_client)
+        self.notification_settings_api = NotificationSettingsApi(api_client)
+        self.pinned_api = PinnedApi(api_client)
+        self.posts_api = PostsApi(api_client)
+        self.received_gifts_api = ReceivedGiftsApi(api_client)
+        self.sticker_packs_api = StickerPacksApi(api_client)
+        self.surveys_api = SurveysApi(api_client)
+        self.threads_api = ThreadsApi(api_client)
+        self.users_api = UsersApi(api_client)
+
+    # ---- tokens / identity (PORTING.md §4) ----
+
+    @property
+    def tokens(self) -> Tokens:
+        # Frozen dataclass — already a value snapshot; mutating it cannot
+        # reach back into the Client.
+        return self._tokens
+
+    def set_tokens(self, access: str, refresh: str) -> None:
+        self._tokens = Tokens(access=access, refresh=refresh)
+
+    @property
+    def device_uuid(self) -> str:
+        return self._device_uuid
+
+    @property
+    def user_id(self) -> int:
+        return self._user_id
+
+    @property
+    def current_email(self) -> str:
+        return self._current_email
+
+    @property
+    def client_ip(self) -> str:
+        return self._client_ip
+
+    def set_login_identity(self, email: str, user_id: int) -> None:
+        """Internal — used by auth.py when activating a session."""
+        self._current_email = email
+        self._user_id = user_id
+
+    def set_device_uuid(self, uuid: str) -> None:
+        """Internal — used by auth.py when a restored session carries a
+        persisted device UUID (PORTING.md §14)."""
+        self._device_uuid = uuid
+        self._transport._ctx.device_uuid = uuid
+
+    # ---- lifecycle ----
+
+    async def __aenter__(self) -> "Client":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        await self._transport.close()
+
+    # ---- auth wrapper (PORTING.md §6) ----
+
+    def login_with_email(self):
+        """LoginWithEmail with transparent session caching. A hit returns
+        the persisted session synthesized into a LoginUserResponse with
+        no HTTP; a miss (or ``.no_cache()``) issues the OAuth login,
+        persists the session, and activates tokens / user id / email.
+        """
+        from yaylib.auth import login_with_email
+
+        return login_with_email(self)
+
+    # ---- 401 auto-refresh (PORTING.md §6.1) ----
+
+    async def _try_refresh(self, stale_access: str) -> bool:
+        # Single-flight: concurrent 401s collapse onto one OAuth /token
+        # round-trip; the others await this same future.
+        if self._refresh_inflight is not None:
+            return await self._refresh_inflight
+        loop = asyncio.get_event_loop()
+        fut: "asyncio.Future[bool]" = loop.create_future()
+        self._refresh_inflight = fut
+        try:
+            result = await self._do_refresh(stale_access)
+            fut.set_result(result)
+            return result
+        except BaseException as exc:  # noqa: BLE001
+            fut.set_exception(exc)
+            raise
+        finally:
+            self._refresh_inflight = None
+
+    async def _do_refresh(self, stale_access: str) -> bool:
+        # A concurrent caller already rotated the token while we queued;
+        # skip the round-trip and let the caller retry with the current
+        # Bearer.
+        if self._tokens.access != stale_access:
+            return True
+        if not self._tokens.refresh:
+            return False
+
+        url = f"{self.base_url}/api/v1/oauth/token"
+        import base64
+
+        basic = base64.b64encode(self.api_key.encode("utf-8")).decode("ascii")
+        form = urlencode(
+            {
+                "grant_type": "refresh_token",
+                "refresh_token": self._tokens.refresh,
+            }
+        )
+        try:
+            res = await self._transport.send_unwrapped(
+                "POST",
+                url,
+                {
+                    "Authorization": f"Basic {basic}",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                form,
+            )
+        except Exception:  # noqa: BLE001
+            return False
+
+        if not (200 <= res.status <= 299):
+            return False
+        try:
+            parsed = json.loads(res.data)
+        except (ValueError, TypeError):
+            return False
+        access = parsed.get("access_token")
+        refresh = parsed.get("refresh_token")
+        if not access or not refresh:
+            return False
+
+        # The server rotates BOTH tokens; persist the new refresh token.
+        self._tokens = Tokens(access=access, refresh=refresh)
+
+        if self.session_store is not None and self._current_email:
+            session = Session(
+                email=self._current_email,
+                user_id=self._user_id,
+                access_token=self._tokens.access,
+                refresh_token=self._tokens.refresh,
+                device_uuid=self._device_uuid,
+                updated_at="",
+            )
+            try:
+                await self.session_store.save(session)
+            except Exception as exc:  # noqa: BLE001
+                # PORTING.md §5: persist failure on the refresh path is
+                # non-fatal — the rotated tokens are still active. Keep
+                # it observable via stdlib logging.
+                _logger.warning(
+                    "yaylib: failed to persist refreshed session: %s", exc
+                )
+
+        return True

--- a/packages/python/yaylib/errors.py
+++ b/packages/python/yaylib/errors.py
@@ -1,0 +1,108 @@
+# PORTING.md §9: three layers of error access — the wire-level APIError,
+# the parsed ErrorResponse body, and the typed error code for match /
+# dispatch.
+#
+# The generated layer raises ``ApiException`` (and the status-specific
+# subclasses ``UnauthorizedException`` / ``BadRequestException`` / ...)
+# carrying the raw body + status. ``APIError`` is the stable, documented
+# name the SDK promises callers — it aliases the generated base so
+# ``except APIError`` recovers every wire error regardless of which
+# subclass the generated code threw.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+from yaylib.exceptions import ApiException as APIError
+
+__all__ = [
+    "APIError",
+    "ErrorResponse",
+    "error_response_of",
+    "code_of",
+    "as_api_error",
+]
+
+
+@dataclass
+class ErrorResponse:
+    """Parsed shape of the Yay! server's JSON error body. Every field is
+    optional because the server emits a subset depending on the code.
+    """
+
+    error_code: Optional[int] = None
+    message: Optional[str] = None
+    ban_until: Optional[int] = None
+    retry_in: Optional[int] = None
+    remaining_quota: Optional[int] = None
+
+
+def _raw_body(err: object) -> Optional[str]:
+    if not isinstance(err, APIError):
+        return None
+    body = getattr(err, "body", None)
+    if isinstance(body, (bytes, bytearray)):
+        try:
+            return body.decode("utf-8")
+        except Exception:
+            return None
+    if isinstance(body, str) and body:
+        return body
+    # Some code paths leave the parsed object on ``data`` instead.
+    data = getattr(err, "data", None)
+    if isinstance(data, str) and data:
+        return data
+    return None
+
+
+def error_response_of(err: object) -> Optional[ErrorResponse]:
+    """Return the parsed payload when ``err`` is an APIError with a JSON
+    body, otherwise ``None`` (never raises).
+    """
+    text = _raw_body(err)
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+
+    def _int(key: str) -> Optional[int]:
+        v = parsed.get(key)
+        return v if isinstance(v, int) and not isinstance(v, bool) else None
+
+    msg = parsed.get("message")
+    return ErrorResponse(
+        error_code=_int("error_code"),
+        message=msg if isinstance(msg, str) else None,
+        ban_until=_int("ban_until"),
+        retry_in=_int("retry_in"),
+        remaining_quota=_int("remaining_quota"),
+    )
+
+
+def code_of(err: object) -> int:
+    """Surface the server's ``error_code`` for match dispatch. Returns 0
+    (the unknown / zero-ish code) when ``err`` is not an APIError or
+    carries no recognizable code. Never raises.
+    """
+    r = error_response_of(err)
+    if r is None or r.error_code is None:
+        return 0
+    return r.error_code
+
+
+def as_api_error(err: BaseException) -> APIError:
+    """Normalize an arbitrary exception into the stable APIError shape.
+
+    A generated ``ApiException`` (or subclass) passes through unchanged so
+    its body / status stay intact; anything else (e.g. an aiohttp
+    transport failure) is wrapped as a status-0 APIError.
+    """
+    if isinstance(err, APIError):
+        return err
+    return APIError(status=0, reason=str(err))

--- a/packages/python/yaylib/event_stream.py
+++ b/packages/python/yaylib/event_stream.py
@@ -1,0 +1,781 @@
+# PORTING.md §10 / §10.1: the multiplexed real-time event channel — one
+# WebSocket against wss://cable.yay.space, N subscriptions on top, Rails
+# ActionCable-style JSON framing. Reference: Go event_stream.go +
+# event_stream_test.go. The wire constants (dial URL shape, channel
+# identifier strings incl. the significant space after ",", frame
+# inventory, event→DTO map) are pattern-matched server-side and MUST be
+# byte-identical across ports.
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import random
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from aiohttp import WSMsgType
+
+DEFAULT_EVENT_STREAM_URL = "wss://cable.yay.space"
+
+_DEFAULT_SUBSCRIBE_TIMEOUT = 10.0
+_DEFAULT_EVENT_BUFFER = 64
+
+# How long a freshly-dialed connection must stay alive before the run
+# loop treats it as healthy and resets the failure budget. Module-level
+# so tests can shrink it; production never rewrites it (mirrors the Go
+# reference's reconnectStableThreshold var).
+reconnect_stable_threshold = 30.0
+
+
+# --------------------------------------------------------------------------
+# Events (events.go parity)
+# --------------------------------------------------------------------------
+
+
+class Event:
+    """Base marker for a server-pushed event."""
+
+
+@dataclass
+class NewMessageEvent(Event):
+    # The full chat-message DTO. Kept as the raw dict so a wire field the
+    # generated RealmMessage model doesn't know (e.g. the WS-only
+    # video_thumbnail_big_url, §10.1) stays observable.
+    raw: Dict[str, Any]
+
+
+@dataclass
+class VideoProcessedEvent(Event):
+    id: int = 0
+    video_processed: bool = False
+    video_url: str = ""
+    video_thumbnail_url: str = ""
+    video_thumbnail_big_url: str = ""
+
+
+@dataclass
+class ChatDeletedEvent(Event):
+    room_id: int = 0
+
+
+@dataclass
+class TotalChatRequestEvent(Event):
+    total_count: int = 0
+
+
+@dataclass
+class UnsubscribedEvent(Event):
+    user_ids: List[int] = field(default_factory=list)
+
+
+@dataclass
+class GroupUpdatedEvent(Event):
+    # Wire event name is `new_post` but the payload is a group-id update
+    # (PORTING.md §10).
+    group_id: int = 0
+
+
+@dataclass
+class CallFinishedEvent(Event):
+    id: int = 0
+
+
+@dataclass
+class RawEvent(Event):
+    """An event whose discriminator the SDK does not recognize. Lets
+    callers observe new server signals before the SDK is updated.
+    """
+
+    name: str
+    data: Dict[str, Any]
+
+
+def decode_event(name: str, data: Dict[str, Any]) -> Optional[Event]:
+    if not isinstance(data, dict):
+        return None
+    if name == "new_message":
+        return NewMessageEvent(raw=data)
+    if name == "video_processed":
+        return VideoProcessedEvent(
+            id=int(data.get("id") or 0),
+            video_processed=bool(data.get("video_processed") or False),
+            video_url=data.get("video_url") or "",
+            video_thumbnail_url=data.get("video_thumbnail_url") or "",
+            video_thumbnail_big_url=data.get("video_thumbnail_big_url") or "",
+        )
+    if name == "chat_deleted":
+        return ChatDeletedEvent(room_id=int(data.get("room_id") or 0))
+    if name == "total_chat_request":
+        return TotalChatRequestEvent(
+            total_count=int(data.get("total_count") or 0)
+        )
+    if name == "unsubscribed":
+        return UnsubscribedEvent(user_ids=list(data.get("user_ids") or []))
+    if name == "new_post":
+        return GroupUpdatedEvent(group_id=int(data.get("group_id") or 0))
+    if name == "conference_call_finished":
+        return CallFinishedEvent(id=int(data.get("id") or 0))
+    return RawEvent(name=name, data=data)
+
+
+# Concrete event type -> its wire `event` name, for routing decoded
+# events to the right decorator handler bucket.
+_TYPE_TO_WIRE = {
+    NewMessageEvent: "new_message",
+    VideoProcessedEvent: "video_processed",
+    ChatDeletedEvent: "chat_deleted",
+    TotalChatRequestEvent: "total_chat_request",
+    UnsubscribedEvent: "unsubscribed",
+    GroupUpdatedEvent: "new_post",
+    CallFinishedEvent: "conference_call_finished",
+}
+
+
+# --------------------------------------------------------------------------
+# Channels (PORTING.md §10.1 — identifier strings are wire-significant:
+# the space after "," matters and the IDs are JSON STRINGS not numbers)
+# --------------------------------------------------------------------------
+
+
+class Channel:
+    def identifier(self) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class _ChatRoomChannel(Channel):
+    def identifier(self) -> str:
+        return '{"channel":"ChatRoomChannel"}'
+
+
+class _MessagesChannel(Channel):
+    def __init__(self, room_id: int) -> None:
+        self._room_id = room_id
+
+    def identifier(self) -> str:
+        return (
+            '{"channel":"MessagesChannel", "chat_room_id":"%d"}'
+            % self._room_id
+        )
+
+
+class _GroupUpdatesChannel(Channel):
+    def identifier(self) -> str:
+        return '{"channel":"GroupUpdatesChannel"}'
+
+
+class _GroupPostsChannel(Channel):
+    def __init__(self, group_id: int) -> None:
+        self._group_id = group_id
+
+    def identifier(self) -> str:
+        return (
+            '{"channel":"GroupPostsChannel", "group_id":"%d"}'
+            % self._group_id
+        )
+
+
+def chat_room_channel() -> Channel:
+    """Global chat-room signals (new requests, deletions, forced unsub)."""
+    return _ChatRoomChannel()
+
+
+def messages_channel(room_id: int) -> Channel:
+    """Messages + video_processed for a single chat room."""
+    return _MessagesChannel(room_id)
+
+
+def group_updates_channel() -> Channel:
+    """Group-membership / group-state updates across all groups."""
+    return _GroupUpdatesChannel()
+
+
+def group_posts_channel(group_id: int) -> Channel:
+    """New posts within a single group's timeline."""
+    return _GroupPostsChannel(group_id)
+
+
+# --------------------------------------------------------------------------
+# Policy / options
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class ReconnectPolicy:
+    # Stop after the first disconnect; subscriptions terminate with the
+    # connection error.
+    disabled: bool = False
+    # Caps total reconnect attempts (excluding the initial dial). 0 means
+    # UNLIMITED — the OPPOSITE of RetryPolicy.max_attempts, because an
+    # unattended event stream wants to keep recovering. Documented loudly
+    # (PORTING.md §13).
+    max_attempts: int = 0
+    # First backoff sleep (seconds); each attempt doubles up to
+    # max_delay, with full jitter.
+    initial_delay: float = 0.5
+    # Ceiling (seconds) on any single sleep between attempts.
+    max_delay: float = 30.0
+
+
+def default_reconnect_policy() -> ReconnectPolicy:
+    return ReconnectPolicy(initial_delay=0.5, max_delay=30.0)
+
+
+@dataclass
+class EventStreamOptions:
+    reconnect: ReconnectPolicy = field(default_factory=default_reconnect_policy)
+    event_buffer: int = _DEFAULT_EVENT_BUFFER
+    subscribe_timeout: float = _DEFAULT_SUBSCRIBE_TIMEOUT
+    # Invoked when a subscription's buffer is full and an event must be
+    # dropped — keeps backpressure observable (PORTING.md §10). Keep it
+    # fast; it runs on the read pump.
+    on_drop: Optional[Callable[[Event], None]] = None
+
+
+# --------------------------------------------------------------------------
+# Subscription
+# --------------------------------------------------------------------------
+
+
+_CLOSED = object()  # queue sentinel signalling terminal
+
+
+class Subscription:
+    def __init__(self, conn: "EventStream", ident: str, buffer: int) -> None:
+        self._conn = conn
+        self.ident = ident
+        self._queue: "asyncio.Queue[Any]" = asyncio.Queue(maxsize=buffer)
+        self._confirm: "asyncio.Future[None]" = (
+            asyncio.get_event_loop().create_future()
+        )
+        self._done = asyncio.Event()
+        self._closed = False
+        self._handlers: Dict[str, List[Callable[[Event], Any]]] = {}
+        self._handler_tasks: "set[asyncio.Task]" = set()
+        self._pump_task: Optional[asyncio.Task] = None
+
+    # ---- consumption: async-iterator path ----
+
+    def __aiter__(self):
+        return self._aiter()
+
+    async def _aiter(self):
+        while True:
+            item = await self._queue.get()
+            if item is _CLOSED:
+                return
+            yield item
+
+    async def next_event(self, timeout: Optional[float] = None) -> Event:
+        """Await the next event. Raises ConnectionError once the
+        subscription has terminated and the buffer is drained.
+        """
+        if timeout is None:
+            item = await self._queue.get()
+        else:
+            item = await asyncio.wait_for(self._queue.get(), timeout)
+        if item is _CLOSED:
+            raise ConnectionError("yaylib: subscription closed")
+        return item
+
+    async def done(self) -> None:
+        await self._done.wait()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    # ---- consumption: decorator path (PORTING.md §10 idiom) ----
+
+    def _register(self, wire: str, fn: Callable[[Event], Any]):
+        self._handlers.setdefault(wire, []).append(fn)
+        # Registering a handler switches the subscription to push mode:
+        # a pump drains the queue into handlers. Starting it here (vs.
+        # at delivery) means events that arrived between subscribe() and
+        # this registration are still dispatched — no race for callers
+        # that wire handlers up right after subscribe.
+        if self._pump_task is None:
+            self._pump_task = asyncio.ensure_future(self._pump())
+        return fn
+
+    async def _pump(self) -> None:
+        try:
+            while True:
+                item = await self._queue.get()
+                if item is _CLOSED:
+                    return
+                wire = _TYPE_TO_WIRE.get(type(item))
+                for cb in self._handlers.get(wire or "", []):
+                    self._spawn_handler(cb, item)
+        except asyncio.CancelledError:
+            raise
+
+    def on_new_message(self, fn):
+        return self._register("new_message", fn)
+
+    def on_video_processed(self, fn):
+        return self._register("video_processed", fn)
+
+    def on_chat_deleted(self, fn):
+        return self._register("chat_deleted", fn)
+
+    def on_total_chat_request(self, fn):
+        return self._register("total_chat_request", fn)
+
+    def on_unsubscribed(self, fn):
+        return self._register("unsubscribed", fn)
+
+    def on_group_updated(self, fn):
+        return self._register("new_post", fn)
+
+    def on_call_finished(self, fn):
+        return self._register("conference_call_finished", fn)
+
+    # ---- delivery (read-pump side) ----
+
+    def _deliver(self, ev: Event) -> None:
+        if self._closed:
+            return
+        try:
+            self._queue.put_nowait(ev)
+        except asyncio.QueueFull:
+            # Buffer full — drop. Surface via on_drop so backpressure is
+            # observable (PORTING.md §10).
+            cb = self._conn._opts.on_drop
+            if cb is not None:
+                cb(ev)
+
+    def _spawn_handler(self, cb: Callable[[Event], Any], ev: Event) -> None:
+        res = cb(ev)
+        if asyncio.iscoroutine(res):
+            task = asyncio.ensure_future(res)
+            self._handler_tasks.add(task)
+            task.add_done_callback(self._handler_tasks.discard)
+
+    def _terminate(self, err: Optional[BaseException]) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if not self._confirm.done():
+            if err is not None:
+                self._confirm.set_exception(err)
+            else:
+                self._confirm.set_exception(
+                    ConnectionError("yaylib: event stream closed")
+                )
+            self._confirm.add_done_callback(
+                lambda f: not f.cancelled() and f.exception()
+            )
+        with contextlib.suppress(asyncio.QueueFull):
+            self._queue.put_nowait(_CLOSED)
+        if self._pump_task is not None:
+            self._pump_task.cancel()
+        self._done.set()
+
+    async def unsubscribe(self) -> None:
+        """Send an unsubscribe command and terminate. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        self._conn._remove_sub(self.ident)
+        with contextlib.suppress(Exception):
+            await self._conn._write_command("unsubscribe", self.ident)
+        if not self._confirm.done():
+            self._confirm.set_exception(
+                ConnectionError("yaylib: unsubscribed")
+            )
+            # Guard against an "exception never retrieved" warning when
+            # nothing is awaiting confirm (unsubscribe before confirm).
+            self._confirm.add_done_callback(
+                lambda f: not f.cancelled() and f.exception()
+            )
+        with contextlib.suppress(asyncio.QueueFull):
+            self._queue.put_nowait(_CLOSED)
+        if self._pump_task is not None:
+            self._pump_task.cancel()
+        self._done.set()
+
+
+# --------------------------------------------------------------------------
+# EventStream
+# --------------------------------------------------------------------------
+
+
+class EventStream:
+    def __init__(
+        self, client, base: str, opts: EventStreamOptions
+    ) -> None:
+        self._client = client
+        self._base = base or DEFAULT_EVENT_STREAM_URL
+        self._opts = opts
+        self._ws = None
+        self._subs: Dict[str, Subscription] = {}
+        self._closed = False
+        self._done = asyncio.Event()
+        self._final_err: Optional[BaseException] = None
+        self._run_task: Optional[asyncio.Task] = None
+
+    # ---- connect / handshake ----
+
+    async def _connect(self) -> None:
+        token_resp = await self._client.users_api.get_web_socket_token()
+        token = getattr(token_resp, "token", "") or ""
+
+        sep = "&" if "?" in self._base else "?"
+        url = (
+            f"{self._base}{sep}token={token}"
+            f"&app_version={self._client.api_version_name}"
+        )
+
+        session = self._client._transport._ensure_session()
+        # No Authorization header on the dial — auth is exclusively the
+        # `token` query parameter (PORTING.md §10.1 / §12).
+        ws = await session.ws_connect(url, heartbeat=None)
+
+        # Welcome handshake: the server sends {"type":"welcome"}
+        # immediately; drain frames until we see it (preceding pings
+        # ignored). A disconnect during welcome is an error.
+        while True:
+            msg = await ws.receive()
+            if msg.type in (
+                WSMsgType.TEXT,
+                WSMsgType.BINARY,
+            ):
+                try:
+                    f = json.loads(msg.data)
+                except (ValueError, TypeError):
+                    continue
+                t = f.get("type")
+                if t == "welcome":
+                    break
+                if t == "disconnect":
+                    await ws.close()
+                    raise ConnectionError(
+                        "yaylib: server disconnect during welcome"
+                    )
+            else:
+                await ws.close()
+                raise ConnectionError("yaylib: ws closed during welcome")
+
+        old = self._ws
+        self._ws = ws
+        if old is not None:
+            with contextlib.suppress(Exception):
+                await old.close()
+
+    # ---- run loop / reconnect ----
+
+    async def _run_loop(self) -> None:
+        try:
+            await self._read_until_disconnect()
+            if self._opts.reconnect.disabled or self._closed:
+                self._terminate_all(self._final_err)
+                return
+
+            attempt = 0
+            while True:
+                if self._closed:
+                    return
+                attempt += 1
+                pol = self._opts.reconnect
+                if pol.max_attempts > 0 and attempt > pol.max_attempts:
+                    err = ConnectionError(
+                        "yaylib: reconnect exhausted after "
+                        f"{pol.max_attempts} attempts: {self._final_err}"
+                    )
+                    self._final_err = err
+                    self._terminate_all(err)
+                    return
+
+                delay = self._backoff(attempt)
+                try:
+                    await asyncio.sleep(delay)
+                except asyncio.CancelledError:
+                    raise
+
+                if self._closed:
+                    return
+                try:
+                    await self._connect()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    self._final_err = exc
+                    continue
+
+                await self._resubscribe_all()
+                started = asyncio.get_event_loop().time()
+                await self._read_until_disconnect()
+                if (
+                    asyncio.get_event_loop().time() - started
+                    >= reconnect_stable_threshold
+                ):
+                    # Survived long enough to be healthy — reset the
+                    # budget so the next blip starts fresh. A faster drop
+                    # counts toward max_attempts so flaps can't loop
+                    # forever.
+                    attempt = 0
+                if self._closed:
+                    return
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._done.set()
+
+    def _backoff(self, attempt: int) -> float:
+        pol = self._opts.reconnect
+        exp = pol.initial_delay * (2 ** max(0, attempt - 1))
+        if exp <= 0 or exp > pol.max_delay:
+            exp = pol.max_delay
+        if exp <= 0:
+            return 0.0
+        delay = random.random() * exp + pol.initial_delay
+        return min(delay, pol.max_delay)
+
+    async def _read_until_disconnect(self) -> None:
+        ws = self._ws
+        if ws is None:
+            return
+        try:
+            async for msg in ws:
+                if msg.type in (WSMsgType.TEXT, WSMsgType.BINARY):
+                    self._dispatch(msg.data)
+                else:
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            self._final_err = exc
+            return
+        # Loop exit = socket closed/errored.
+        if self._final_err is None and not self._closed:
+            self._final_err = ConnectionError("yaylib: connection dropped")
+
+    # ---- dispatch ----
+
+    def _dispatch(self, data) -> None:
+        try:
+            f = json.loads(data)
+        except (ValueError, TypeError):
+            return
+        if not isinstance(f, dict):
+            return
+        ftype = f.get("type")
+        if ftype == "welcome":
+            return
+        if ftype == "ping":
+            return
+        if ftype == "disconnect":
+            # Bubble up by closing the ws so the read loop exits and
+            # reconnect kicks in.
+            ws = self._ws
+            if ws is not None:
+                asyncio.ensure_future(self._safe_close_ws(ws))
+            return
+        if ftype == "confirm_subscription":
+            sub = self._subs.get(f.get("identifier", ""))
+            if sub is not None and not sub._confirm.done():
+                sub._confirm.set_result(None)
+            return
+        if ftype == "reject_subscription":
+            sub = self._subs.get(f.get("identifier", ""))
+            if sub is not None:
+                err = ConnectionError("yaylib: subscription rejected")
+                if not sub._confirm.done():
+                    sub._confirm.set_exception(err)
+                sub._terminate(err)
+            return
+
+        message = f.get("message")
+        if not message:
+            return
+        if isinstance(message, str):
+            try:
+                message = json.loads(message)
+            except (ValueError, TypeError):
+                return
+        if not isinstance(message, dict):
+            return
+        name = message.get("event") or ""
+        body = message.get("data")
+        if body is None:
+            body = message.get("message")
+        if not name or body is None:
+            return
+        ev = decode_event(name, body)
+        if ev is None:
+            return
+        sub = self._subs.get(f.get("identifier", ""))
+        if sub is not None:
+            sub._deliver(ev)
+
+    async def _safe_close_ws(self, ws) -> None:
+        with contextlib.suppress(Exception):
+            await ws.close()
+
+    # ---- subscription management ----
+
+    def _remove_sub(self, ident: str) -> None:
+        self._subs.pop(ident, None)
+
+    async def _resubscribe_all(self) -> None:
+        for ident in list(self._subs.keys()):
+            with contextlib.suppress(Exception):
+                await self._write_command("subscribe", ident)
+
+    def _terminate_all(self, err: Optional[BaseException]) -> None:
+        subs = list(self._subs.values())
+        self._subs = {}
+        for s in subs:
+            s._terminate(err)
+
+    async def _write_command(self, cmd: str, identifier: str) -> None:
+        ws = self._ws
+        if ws is None:
+            raise ConnectionError("yaylib: ws not connected")
+        await ws.send_str(
+            json.dumps({"command": cmd, "identifier": identifier})
+        )
+
+    async def subscribe(self, channel: Channel) -> Subscription:
+        if self._closed:
+            raise ConnectionError("yaylib: event stream closed")
+        ident = channel.identifier()
+        existing = self._subs.get(ident)
+        if existing is not None:
+            return await self._await_confirm(existing, owned=False)
+
+        sub = Subscription(self, ident, self._opts.event_buffer)
+        self._subs[ident] = sub
+        try:
+            await self._write_command("subscribe", ident)
+        except Exception as exc:  # noqa: BLE001
+            self._remove_sub(ident)
+            raise ConnectionError(
+                f"yaylib: subscribe {ident}: {exc}"
+            ) from exc
+        return await self._await_confirm(sub, owned=True)
+
+    async def _await_confirm(
+        self, sub: Subscription, owned: bool
+    ) -> Subscription:
+        timeout = self._opts.subscribe_timeout
+
+        async def _wait_done():
+            await self._done.wait()
+
+        done_wait = asyncio.ensure_future(_wait_done())
+        try:
+            await asyncio.wait(
+                {sub._confirm, done_wait},
+                timeout=timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not sub._confirm.done() and not self._done.is_set():
+                if owned:
+                    self._remove_sub(sub.ident)
+                raise ConnectionError(
+                    f"yaylib: subscribe {sub.ident}: timed out after "
+                    f"{timeout}s"
+                )
+            if sub._confirm.done():
+                exc = sub._confirm.exception()
+                if exc is not None:
+                    if owned:
+                        self._remove_sub(sub.ident)
+                    raise exc
+                return sub
+            # stream done fired first
+            if owned:
+                self._remove_sub(sub.ident)
+            if self._final_err is not None:
+                raise self._final_err
+            raise ConnectionError("yaylib: event stream closed")
+        finally:
+            done_wait.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await done_wait
+
+    # ---- lifecycle ----
+
+    async def _open(self) -> "EventStream":
+        await self._connect()
+        self._run_task = asyncio.ensure_future(self._run_loop())
+        return self
+
+    async def close(self) -> None:
+        if self._closed:
+            await self._done.wait()
+            return
+        self._closed = True
+        ws = self._ws
+        if ws is not None:
+            with contextlib.suppress(Exception):
+                await ws.close()
+        if self._run_task is not None:
+            self._run_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._run_task
+        self._terminate_all(None)
+        self._done.set()
+
+    async def wait_done(self) -> None:
+        await self._done.wait()
+
+    def err(self) -> Optional[BaseException]:
+        """Terminal error after the stream is done. None for a clean,
+        caller-initiated close; non-nil if the stream died on its own.
+        """
+        if not self._done.is_set():
+            return None
+        if self._closed:
+            return None
+        return self._final_err
+
+    async def __aenter__(self) -> "EventStream":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+
+class _OpenEventStreamCM:
+    """Returned by ``client.open_event_stream(...)``. Works both as
+    ``async with client.open_event_stream(opts) as stream`` and
+    ``stream = await client.open_event_stream(opts)``.
+    """
+
+    def __init__(self, client, opts: Optional[EventStreamOptions]) -> None:
+        self._client = client
+        self._opts = opts or EventStreamOptions()
+        self._stream: Optional[EventStream] = None
+
+    async def _start(self) -> EventStream:
+        opts = self._opts
+        if opts.reconnect.initial_delay <= 0:
+            opts.reconnect.initial_delay = 0.5
+        if opts.reconnect.max_delay <= 0:
+            opts.reconnect.max_delay = 30.0
+        if opts.event_buffer <= 0:
+            opts.event_buffer = _DEFAULT_EVENT_BUFFER
+        if opts.subscribe_timeout <= 0:
+            opts.subscribe_timeout = _DEFAULT_SUBSCRIBE_TIMEOUT
+        stream = EventStream(
+            self._client, self._client.event_stream_url, opts
+        )
+        await stream._open()
+        self._client._event_streams.add(stream)
+        self._stream = stream
+        return stream
+
+    def __await__(self):
+        return self._start().__await__()
+
+    async def __aenter__(self) -> EventStream:
+        return await self._start()
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._stream is not None:
+            await self._stream.close()
+            self._client._event_streams.discard(self._stream)

--- a/packages/python/yaylib/retry.py
+++ b/packages/python/yaylib/retry.py
@@ -1,0 +1,77 @@
+# PORTING.md §13: retry policy for transient failures (429, 5xx,
+# transport errors). The wire contract:
+#
+#   - 429 retries on every method — the server explicitly asked.
+#   - 5xx / transport errors retry only on safe methods (GET / HEAD /
+#     PUT / DELETE / OPTIONS) by default. POST / PATCH retry only when
+#     ``retry_on_post`` is True because the Yay! server has no
+#     idempotency-key concept.
+#   - The response body's ``retry_in`` field, when present, is honored
+#     over the computed exponential backoff (seconds).
+#   - Backoff is exponential with full jitter, clamped to ``max_delay``.
+#   - The zero value (``RetryPolicy(max_attempts=0)``) disables retry.
+#
+# Delays are expressed in SECONDS (Python idiom — Go uses
+# time.Duration, TS uses milliseconds). ``ReconnectPolicy`` (the
+# event-stream sibling) has the OPPOSITE zero semantics:
+# ``max_attempts == 0`` there means "unlimited".
+
+from __future__ import annotations
+
+import random as _random
+from dataclasses import dataclass
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "PUT", "DELETE", "OPTIONS"})
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    # Total attempt cap (initial attempt + retries). 0 or 1 disables
+    # retry. Default: 3.
+    max_attempts: int = 3
+    # Base delay (seconds) before the first retry. Default: 0.2s.
+    base_delay: float = 0.2
+    # Hard ceiling (seconds) on any single sleep. Default: 30s.
+    max_delay: float = 30.0
+    # Allow retrying POST / PATCH on 5xx / transport errors. Default:
+    # False. 429 retries on every method regardless.
+    retry_on_post: bool = False
+
+
+DEFAULT_RETRY_POLICY = RetryPolicy(
+    max_attempts=3, base_delay=0.2, max_delay=30.0, retry_on_post=False
+)
+
+
+def method_allows_retry(method: str, policy: RetryPolicy) -> bool:
+    """True if ``method`` may retry on 5xx / transport errors under the
+    policy. 429 is handled separately (it retries on every method).
+    """
+    m = method.upper()
+    if m in _SAFE_METHODS:
+        return True
+    if m in ("POST", "PATCH"):
+        return policy.retry_on_post
+    return False
+
+
+def should_retry_status(status: int, method: str, policy: RetryPolicy) -> bool:
+    if status == 429:
+        return True
+    if 500 <= status <= 599:
+        return method_allows_retry(method, policy)
+    return False
+
+
+def full_jitter_delay(
+    attempt: int, policy: RetryPolicy, rand=_random.random
+) -> float:
+    """Random duration in ``[0, min(max_delay, base_delay * 2^(attempt-1))]``.
+
+    ``attempt`` is the upcoming retry's 1-indexed number (1 = first retry).
+    """
+    exp = min(
+        policy.max_delay,
+        policy.base_delay * (2 ** max(0, attempt - 1)),
+    )
+    return rand() * exp

--- a/packages/python/yaylib/session.py
+++ b/packages/python/yaylib/session.py
@@ -1,0 +1,95 @@
+# PORTING.md §5: SessionStore persists (email -> Session) pairs so tokens
+# survive across process restarts. This module ships the interface and an
+# in-memory implementation; the file-backed default lives in
+# session_file.py and is loaded via new_session_store.
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+
+
+def _now_rfc3339() -> str:
+    # RFC3339 / ISO8601 with a trailing 'Z', matching the Go reference's
+    # time.RFC3339 output for UTC.
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+
+@dataclass
+class Session:
+    """One persisted identity. Field names mirror the §5.1 JSON schema
+    so the file representation is a direct dump of this dataclass.
+    """
+
+    email: str = ""
+    user_id: int = 0
+    access_token: str = ""
+    refresh_token: str = ""
+    device_uuid: str = ""
+    updated_at: str = ""  # RFC3339
+
+
+class NoSessionError(Exception):
+    """Sentinel raised by ``SessionStore.load`` on a cache miss."""
+
+    def __init__(self, email: str) -> None:
+        super().__init__(f"yaylib: no session for {email}")
+        self.email = email
+
+
+class SessionSaveFailed(Exception):
+    """Raised by login_with_email when persisting a fresh session fails.
+
+    The login response is still returned and the tokens are active in
+    memory (PORTING.md §5); only the persistence step failed.
+    """
+
+    def __init__(self, cause: BaseException) -> None:
+        super().__init__(f"yaylib: failed to persist session: {cause}")
+        self.cause = cause
+
+
+class SessionStore(abc.ABC):
+    @abc.abstractmethod
+    async def load(self, email: str) -> Session:
+        """Return the cached session or raise NoSessionError."""
+
+    @abc.abstractmethod
+    async def save(self, session: Session) -> None:
+        """Upsert. Called after fresh login and after each refresh."""
+
+    @abc.abstractmethod
+    async def delete(self, email: str) -> None:
+        """Idempotent; a missing key is not an error."""
+
+
+class MemorySessionStore(SessionStore):
+    def __init__(self) -> None:
+        self._sessions: dict[str, Session] = {}
+
+    async def load(self, email: str) -> Session:
+        s = self._sessions.get(email)
+        if s is None:
+            raise NoSessionError(email)
+        return replace(s)
+
+    async def save(self, session: Session) -> None:
+        if not session.email:
+            raise ValueError("yaylib: SessionStore.save: email is required")
+        stored = replace(
+            session,
+            updated_at=session.updated_at or _now_rfc3339(),
+        )
+        self._sessions[stored.email] = stored
+
+    async def delete(self, email: str) -> None:
+        self._sessions.pop(email, None)
+
+
+def new_memory_store() -> SessionStore:
+    return MemorySessionStore()

--- a/packages/python/yaylib/session_file.py
+++ b/packages/python/yaylib/session_file.py
@@ -1,0 +1,145 @@
+# PORTING.md §5.1: file-backed SessionStore. Persists sessions as a JSON
+# document keyed by email so one file can hold multiple identities.
+# Writes are atomic within a single process (temp-file + rename); the
+# file is created with mode 0o600 because it carries access tokens.
+# Multi-process writers are out of scope (PORTING.md §5).
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import os
+from typing import Optional
+
+from yaylib.session import (
+    NoSessionError,
+    Session,
+    SessionStore,
+    _now_rfc3339,
+)
+
+_FIELDS = (
+    "email",
+    "user_id",
+    "access_token",
+    "refresh_token",
+    "device_uuid",
+    "updated_at",
+)
+
+
+def _session_from_dict(email: str, raw: dict) -> Session:
+    return Session(
+        email=raw.get("email") or email,
+        user_id=int(raw.get("user_id") or 0),
+        access_token=raw.get("access_token") or "",
+        refresh_token=raw.get("refresh_token") or "",
+        device_uuid=raw.get("device_uuid") or "",
+        updated_at=raw.get("updated_at") or "",
+    )
+
+
+class FileSessionStore(SessionStore):
+    """One-process-safe file store. The asyncio lock serializes the
+    read-modify-write cycle so concurrent save / delete calls don't lose
+    updates. Cross-process safety is not provided (PORTING.md §5).
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        # Created lazily so construction works outside a running loop
+        # (Client is built synchronously).
+        self._lock: Optional[asyncio.Lock] = None
+
+    def _mu(self) -> asyncio.Lock:
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
+
+    async def load(self, email: str) -> Session:
+        async with self._mu():
+            data = self._read_all()
+            raw = data["sessions"].get(email)
+            if raw is None:
+                raise NoSessionError(email)
+            return _session_from_dict(email, raw)
+
+    async def save(self, session: Session) -> None:
+        if not session.email:
+            raise ValueError("yaylib: SessionStore.save: email is required")
+        async with self._mu():
+            data = self._read_all()
+            record = dataclasses.asdict(session)
+            record["updated_at"] = session.updated_at or _now_rfc3339()
+            data["sessions"][session.email] = {
+                k: record[k] for k in _FIELDS
+            }
+            self._write_all(data)
+
+    async def delete(self, email: str) -> None:
+        async with self._mu():
+            data = self._read_all()
+            if email not in data["sessions"]:
+                return
+            del data["sessions"][email]
+            self._write_all(data)
+
+    # ---- blocking helpers, only ever called inside the lock ----
+
+    def _read_all(self) -> dict:
+        try:
+            with open(self._path, "r", encoding="utf-8") as fh:
+                text = fh.read()
+        except FileNotFoundError:
+            return {"sessions": {}}
+        try:
+            parsed = json.loads(text) if text else {}
+        except ValueError as err:
+            raise ValueError(
+                f"yaylib: failed to parse session file {self._path}: {err}"
+            ) from err
+        sessions = parsed.get("sessions") if isinstance(parsed, dict) else None
+        return {"sessions": sessions if isinstance(sessions, dict) else {}}
+
+    def _write_all(self, data: dict) -> None:
+        directory = os.path.dirname(self._path)
+        if directory and directory != ".":
+            os.makedirs(directory, mode=0o700, exist_ok=True)
+        tmp = f"{self._path}.tmp"
+        # Open with explicit mode so the token-bearing file is 0o600 even
+        # if it didn't exist yet.
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        try:
+            os.replace(tmp, self._path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        # os.replace preserves the destination's prior mode when it
+        # already existed; re-assert 0o600 unconditionally.
+        try:
+            os.chmod(self._path, 0o600)
+        except OSError:
+            pass
+
+
+async def new_session_store(path: str) -> SessionStore:
+    """Default factory. Creates the parent directory eagerly so
+    subsequent saves never fail on a missing path.
+    """
+    directory = os.path.dirname(path)
+    if directory and directory != ".":
+        os.makedirs(directory, mode=0o700, exist_ok=True)
+    return FileSessionStore(path)

--- a/packages/python/yaylib/signing.py
+++ b/packages/python/yaylib/signing.py
@@ -1,0 +1,94 @@
+# PORTING.md §7: signed_info / signed_version / X-Jwt.
+#
+# All three helpers produce byte-identical output to the Go reference
+# against the test vectors pinned in PORTING.md §7.1. Python targets
+# server-side runtimes (PORTING.md "Runtime scope"), so ``hashlib.md5``
+# is always available — no polyfill needed.
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+from dataclasses import dataclass
+
+from yaylib._config import SIGNED_INFO_SHARED_KEY, SIGNED_VERSION_PLATFORM
+
+
+@dataclass(frozen=True)
+class SignedInfo:
+    """Bundles the timestamp and MD5 hash a Yay! request needs to pass
+    server-side validation. The two values are bound: changing one
+    without the other invalidates the signature.
+    """
+
+    # Unix-second timestamp the hash is computed against. Send this as
+    # the request's ``timestamp`` field.
+    timestamp: int
+    # Lowercase 32-char MD5 hex digest. Send this as ``signed_info``.
+    value: str
+
+
+def generate_signed_info_at(
+    *, api_key: str, device_uuid: str, timestamp: int
+) -> SignedInfo:
+    """Compute the signed_info MD5 for ``timestamp`` with no network I/O.
+
+    Use this when you already have a synchronized timestamp; otherwise
+    prefer ``Client.generate_signed_info`` which fetches the server's
+    view of the clock to avoid device-clock drift.
+    """
+    payload = f"{api_key}{device_uuid}{timestamp}{SIGNED_INFO_SHARED_KEY}"
+    value = hashlib.md5(payload.encode("utf-8")).hexdigest()
+    return SignedInfo(timestamp=timestamp, value=value)
+
+
+def generate_signed_version(
+    *, api_version_key: str, api_version_name: str
+) -> str:
+    """The signed_version HMAC token some endpoints require alongside
+    signed_info. The platform identifier is hard-coded to ``yay_android``
+    to stay inside the server's platform allowlist.
+    """
+    payload = f"{SIGNED_VERSION_PLATFORM}/{api_version_name}"
+    digest = hmac.new(
+        api_version_key.encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    # Standard base64 with padding; no trailing newline (stdlib does not
+    # add one, but be explicit about the contract).
+    return base64.b64encode(digest).decode("ascii")
+
+
+def generate_x_jwt(
+    *, api_version_key: str, now: int | None = None, ttl_seconds: int = 5
+) -> str:
+    """The short-lived HS256 JWT required by some write endpoints (most
+    visibly create_post). ``iat`` is the current Unix-second time;
+    ``exp`` = iat + ttl_seconds; the HS256 key is APIVersionKey. TTL is
+    5 seconds, so callers MUST regenerate per request.
+    """
+    iat = int(time.time()) if now is None else now
+    exp = iat + ttl_seconds
+    return _sign_jwt(api_version_key, iat, exp)
+
+
+def _b64url_no_pad(raw: bytes) -> str:
+    # RFC 4648 §5, padding stripped.
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _sign_jwt(key: str, iat: int, exp: int) -> str:
+    # Header JSON has no ``typ`` and no spaces; payload JSON key order is
+    # ``iat`` then ``exp``, also no spaces.
+    header = _b64url_no_pad(b'{"alg":"HS256"}')
+    payload = _b64url_no_pad(
+        f'{{"iat":{iat},"exp":{exp}}}'.encode("utf-8")
+    )
+    signing_input = f"{header}.{payload}"
+    sig = hmac.new(
+        key.encode("utf-8"), signing_input.encode("utf-8"), hashlib.sha256
+    ).digest()
+    return f"{signing_input}.{_b64url_no_pad(sig)}"

--- a/packages/python/yaylib/tokens.py
+++ b/packages/python/yaylib/tokens.py
@@ -1,0 +1,18 @@
+# PORTING.md §4: Tokens is the immutable snapshot of OAuth credentials.
+# Mutate by going through Client.set_tokens, login_with_email,
+# load_session, or the internal 401 refresh path — never by mutating a
+# returned snapshot.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Tokens:
+    access: str = ""
+    refresh: str = ""
+
+
+def empty_tokens() -> Tokens:
+    return Tokens(access="", refresh="")

--- a/packages/python/yaylib/transport.py
+++ b/packages/python/yaylib/transport.py
@@ -1,0 +1,336 @@
+# PORTING.md §12 / §6.1 / §13: the transport replaces the generated
+# ``rest_client``. It injects the headers the Yay! server validates,
+# picks the right Authorization scheme, runs the 401 auto-refresh chain,
+# and applies the retry policy — all funnelled through one ``request``
+# coroutine the generated ``ApiClient`` already calls.
+#
+# Re-sends (the post-401 replay and the transient-failure retry) go
+# through the same bare ``aiohttp`` session used for the first attempt,
+# NOT back through a wrapped client — there is no recursion hazard here
+# because this object is the bottom of the stack (PORTING.md §6.1 note).
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import re
+import time
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional
+
+import aiohttp
+from multidict import CIMultiDict
+
+from yaylib.exceptions import ApiException, ApiValueError
+from yaylib.retry import (
+    RetryPolicy,
+    full_jitter_delay,
+    method_allows_retry,
+    should_retry_status,
+)
+
+_OAUTH_TOKEN_PATH = "/api/v1/oauth/token"
+
+
+def _is_oauth_token_path(url: str) -> bool:
+    return _OAUTH_TOKEN_PATH in url
+
+
+@dataclass
+class TransportContext:
+    user_agent: str
+    app_version: str  # sent as X-App-Version
+    device_info: str
+    device_uuid: str
+    connection_type: str
+    connection_speed: str
+    accept_language: str
+    api_key: str
+    client_ip: Callable[[], str]
+    access_token: Callable[[], str]
+
+
+# RefreshFn attempts a one-shot refresh of the access token using the
+# stale value carried by the original 401 request. Implementations MUST
+# collapse concurrent calls (PORTING.md §6.1). Returns True when the
+# access token is now fresh (retry the original request), False when
+# refresh failed (surface the original 401 to the caller).
+RefreshFn = Callable[[str], Awaitable[bool]]
+
+
+class BufferedResponse:
+    """RESTResponse-compatible wrapper. The body is read fully up-front
+    so the response is decoupled from the connection — required for the
+    retry path (we discard intermediate responses) and so the session
+    can close without keep-alive sockets hanging.
+    """
+
+    def __init__(self, status: int, reason: Optional[str], headers, data: bytes):
+        self.status = status
+        self.reason = reason
+        self._headers = headers
+        self.data = data
+
+    async def read(self) -> bytes:
+        return self.data
+
+    def getheaders(self) -> "CIMultiDict[str]":
+        return self._headers
+
+    def getheader(self, name: str, default=None):
+        return self._headers.get(name, default)
+
+
+def _find_header(headers: dict, name: str) -> Optional[str]:
+    lname = name.lower()
+    for k in headers:
+        if k.lower() == lname:
+            return k
+    return None
+
+
+def _set_if_absent(headers: dict, key: str, value: str) -> None:
+    if not value:
+        return
+    if _find_header(headers, key) is None:
+        headers[key] = value
+
+
+def _timeout(_request_timeout) -> aiohttp.ClientTimeout:
+    if _request_timeout is None:
+        return aiohttp.ClientTimeout(total=5 * 60)
+    if isinstance(_request_timeout, (int, float)):
+        return aiohttp.ClientTimeout(total=float(_request_timeout))
+    if isinstance(_request_timeout, (tuple, list)) and len(_request_timeout) == 2:
+        return aiohttp.ClientTimeout(
+            sock_connect=float(_request_timeout[0]),
+            sock_read=float(_request_timeout[1]),
+        )
+    return aiohttp.ClientTimeout(total=5 * 60)
+
+
+class Transport:
+    """Drop-in replacement for the generated ``RESTClientObject``."""
+
+    def __init__(
+        self,
+        *,
+        ctx: TransportContext,
+        refresh: RefreshFn,
+        policy: RetryPolicy,
+    ) -> None:
+        self._ctx = ctx
+        self._refresh = refresh
+        self._policy = policy
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    def _ensure_session(self) -> aiohttp.ClientSession:
+        # Created lazily inside the running loop — Client is built
+        # synchronously and aiohttp refuses a session without a loop.
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # ---- body serialization (mirrors the generated rest.py) ----
+
+    @staticmethod
+    def _serialize_body(headers: dict, body, post_params):
+        if post_params and body:
+            raise ApiValueError(
+                "body parameter cannot be used with post_params parameter."
+            )
+        ct_key = _find_header(headers, "content-type")
+        content_type = headers[ct_key] if ct_key else "application/json"
+        if re.search("json", content_type, re.IGNORECASE):
+            return json.dumps(body) if body is not None else None
+        if content_type == "application/x-www-form-urlencoded":
+            return aiohttp.FormData(post_params or [])
+        if content_type == "multipart/form-data":
+            data = aiohttp.FormData()
+            for param in post_params or []:
+                k, v = param
+                if isinstance(v, tuple) and len(v) == 3:
+                    data.add_field(
+                        k, value=v[1], filename=v[0], content_type=v[2]
+                    )
+                else:
+                    if isinstance(v, dict):
+                        v = json.dumps(v)
+                    elif isinstance(v, int):
+                        v = str(v)
+                    data.add_field(k, v)
+            return data
+        if isinstance(body, (str, bytes)):
+            return body
+        if body is None:
+            return None
+        raise ApiException(
+            status=0,
+            reason="Cannot prepare a request message for provided arguments.",
+        )
+
+    # ---- header injection (PORTING.md §12) ----
+
+    def _build_headers(self, base: dict, url: str) -> dict:
+        headers = dict(base)
+        ctx = self._ctx
+        _set_if_absent(headers, "User-Agent", ctx.user_agent)
+        _set_if_absent(headers, "X-App-Version", ctx.app_version)
+        _set_if_absent(headers, "X-Device-Info", ctx.device_info)
+        _set_if_absent(headers, "X-Device-UUID", ctx.device_uuid)
+        _set_if_absent(headers, "X-Client-IP", ctx.client_ip())
+        _set_if_absent(headers, "X-Connection-Type", ctx.connection_type)
+        _set_if_absent(headers, "X-Connection-Speed", ctx.connection_speed)
+        _set_if_absent(headers, "Accept-Language", ctx.accept_language)
+
+        # X-Timestamp must be fresh per request (never cached).
+        ts_key = _find_header(headers, "x-timestamp")
+        if ts_key:
+            del headers[ts_key]
+        headers["X-Timestamp"] = str(int(time.time()))
+
+        # Normalize JSON Content-Type to the exact casing / spacing the
+        # server expects.
+        ct_key = _find_header(headers, "content-type")
+        if ct_key is None:
+            headers["Content-Type"] = "application/json;charset=UTF-8"
+        elif headers[ct_key].lower().startswith("application/json"):
+            headers[ct_key] = "application/json;charset=UTF-8"
+
+        # Authorization: Basic for oauth/token*, Bearer for everything
+        # else. Caller-provided Authorization wins (set-if-absent).
+        if _find_header(headers, "authorization") is None:
+            if _is_oauth_token_path(url):
+                token = base64.b64encode(
+                    ctx.api_key.encode("utf-8")
+                ).decode("ascii")
+                headers["Authorization"] = f"Basic {token}"
+            else:
+                access = ctx.access_token()
+                if access:
+                    headers["Authorization"] = f"Bearer {access}"
+        return headers
+
+    async def _raw(
+        self, method: str, url: str, headers: dict, data, timeout
+    ) -> BufferedResponse:
+        session = self._ensure_session()
+        async with session.request(
+            method, url, headers=headers, data=data, timeout=timeout
+        ) as resp:
+            body = await resp.read()
+            return BufferedResponse(
+                resp.status,
+                resp.reason,
+                CIMultiDict(resp.headers),
+                body,
+            )
+
+    async def send_unwrapped(
+        self, method: str, url: str, headers: dict, data, timeout=None
+    ) -> BufferedResponse:
+        """Bare round-trip with no header injection / refresh / retry.
+
+        Used by the OAuth refresh path (PORTING.md §6.1: re-issue with the
+        UNWRAPPED HTTP client) so it can never recurse back into the
+        refresh hook.
+        """
+        return await self._raw(
+            method.upper(), url, headers, data, _timeout(timeout)
+        )
+
+    @staticmethod
+    def _retry_in_seconds(resp: BufferedResponse) -> Optional[float]:
+        if not resp.data:
+            return None
+        try:
+            parsed = json.loads(resp.data)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        v = parsed.get("retry_in")
+        if isinstance(v, (int, float)) and not isinstance(v, bool) and v >= 0:
+            return float(v)
+        return None
+
+    async def request(
+        self,
+        method,
+        url,
+        headers=None,
+        body=None,
+        post_params=None,
+        _request_timeout=None,
+    ) -> BufferedResponse:
+        method = method.upper()
+        base_headers = dict(headers or {})
+        data = self._serialize_body(base_headers, body, post_params)
+        timeout = _timeout(_request_timeout)
+
+        policy = self._policy
+        retry_enabled = policy.max_attempts > 1
+        is_oauth = _is_oauth_token_path(url)
+
+        attempt = 1  # number of sends performed (initial counts as 1)
+        did_refresh = False
+
+        while True:
+            send_headers = self._build_headers(base_headers, url)
+            auth = send_headers.get(_find_header(send_headers, "authorization") or "")
+            stale_access = (
+                auth[7:] if isinstance(auth, str) and auth.startswith("Bearer ")
+                else ""
+            )
+
+            try:
+                resp = await self._raw(
+                    method, url, send_headers, data, timeout
+                )
+            except asyncio.CancelledError:
+                raise
+            except aiohttp.ClientError as exc:
+                if (
+                    retry_enabled
+                    and method_allows_retry(method, policy)
+                    and attempt < policy.max_attempts
+                ):
+                    delay = min(
+                        full_jitter_delay(attempt, policy), policy.max_delay
+                    )
+                    await asyncio.sleep(delay)
+                    attempt += 1
+                    continue
+                raise ApiException(status=0, reason=str(exc)) from exc
+
+            # 401 auto-refresh (PORTING.md §6.1). The replay after a
+            # successful refresh is OUTSIDE the retry budget — it mirrors
+            # the Go/TS split where refresh and retry are separate hooks.
+            if resp.status == 401 and not is_oauth and not did_refresh:
+                if await self._refresh(stale_access):
+                    did_refresh = True
+                    continue
+                return resp
+
+            if (
+                retry_enabled
+                and should_retry_status(resp.status, method, policy)
+                and attempt < policy.max_attempts
+            ):
+                body_wait = self._retry_in_seconds(resp)
+                delay = (
+                    body_wait
+                    if body_wait is not None
+                    else full_jitter_delay(attempt, policy)
+                )
+                await asyncio.sleep(delay)
+                attempt += 1
+                continue
+
+            return resp

--- a/packages/python/yaylib/transport.py
+++ b/packages/python/yaylib/transport.py
@@ -31,10 +31,18 @@ from yaylib.retry import (
 )
 
 _OAUTH_TOKEN_PATH = "/api/v1/oauth/token"
+_TIMESTAMP_PATH = "/v2/users/timestamp"
 
 
 def _is_oauth_token_path(url: str) -> bool:
     return _OAUTH_TOKEN_PATH in url
+
+
+def _is_timestamp_path(url: str) -> bool:
+    # The endpoint used to look up the caller's IP for X-Client-IP. The
+    # lazy fetch must not re-trigger itself when calling it.
+    path = url.split("?", 1)[0]
+    return path.endswith(_TIMESTAMP_PATH)
 
 
 @dataclass
@@ -119,10 +127,14 @@ class Transport:
         ctx: TransportContext,
         refresh: RefreshFn,
         policy: RetryPolicy,
+        on_response: Optional[Callable[[], None]] = None,
     ) -> None:
         self._ctx = ctx
         self._refresh = refresh
         self._policy = policy
+        # Fired after any non-timestamp request gets a response — drives
+        # the Client's lazy X-Client-IP fetch (PORTING.md §12).
+        self._on_response = on_response
         self._session: Optional[aiohttp.ClientSession] = None
 
     def _ensure_session(self) -> aiohttp.ClientSession:
@@ -308,6 +320,13 @@ class Transport:
                     attempt += 1
                     continue
                 raise ApiException(status=0, reason=str(exc)) from exc
+
+            # Kick the lazy X-Client-IP fetch on the first non-timestamp
+            # request (PORTING.md §12). Skip the fetch endpoint itself to
+            # avoid recursion; the Client side single-flights / no-ops
+            # when the IP is already known.
+            if self._on_response is not None and not _is_timestamp_path(url):
+                self._on_response()
 
             # 401 auto-refresh (PORTING.md §6.1). The replay after a
             # successful refresh is OUTSIDE the retry budget — it mirrors


### PR DESCRIPTION
## 概要

`packages/python/` の手書き層を実装し、Go リファレンス(`*.go` / `*_test.go`)と PORTING.md のクロス言語契約に揃えた Python ポート。生成物層(`api/` `models/` `rest.py` `configuration.py` 等)は不変。

## 実装(ブリーフの手書きモジュール全 7 点)

- `signing.py` — signed_info / signed_version / X-Jwt(golden vector 一致, §7)
- `tokens.py` / `session.py` / `session_file.py` — 不変スナップショット + SessionStore(Memory/File, §4/§5)
- `errors.py` / `_config.py` — APIError 三層 + 埋め込み wire 定数(§9/§3.1)
- `retry.py` — RetryPolicy(秒, zero-value 無効, §13)
- `transport.py` — 必須ヘッダ注入・401 自動 refresh・retry・遅延 X-Client-IP(§12/§6.1/§13)
- `auth.py` — login_with_email(透過セッションキャッシュ, §6)
- `client.py` — 23 API ハンドル・single-flight refresh・lifecycle(§2/§3)
- `event_stream.py` — ActionCable WebSocket multiplexed stream(§10/§10.1)

## テスト: 47 件 green

Go `*_test.go` のシナリオを翻訳(API 機構ではなく挙動を翻訳, §15):

- signing golden ×3 / session_file ×6 / 401-refresh 3 ケース / auth 5 / retry 7
- 必須ヘッダ・OAuth=Basic / 遅延 X-Client-IP / エラー三層・2FA / event_stream 13

## スコープ外(意図的)

- `execute_raw`(§11.3)・tolerant enum / 非 path 任意化(§11)・typed `ErrorCode` カタログ(§9) — Go でも `gen/` 生成物。再生成は統合担当領域(ブリーフ準拠)
- フラット operation promotion(§2)・アップロード(§8) — ブリーフの手書きモジュール列挙外

実行: `cd packages/python && pytest`(aiohttp / pydantic v2 / pytest-asyncio)