### PR TITLE
feat(python): upload layer + behavior parity

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -18,6 +18,7 @@ aiohttp = ">= 3.8.4"
 aiohttp-retry = ">= 2.8.3"
 pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"
+pillow = ">= 9.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = ">= 7.2.1"

--- a/packages/python/requirements.txt
+++ b/packages/python/requirements.txt
@@ -4,3 +4,4 @@ aiohttp >= 3.8.4
 aiohttp-retry >= 2.8.3
 pydantic >= 2
 typing-extensions >= 4.7.1
+pillow >= 9.0.0

--- a/packages/python/setup.py
+++ b/packages/python/setup.py
@@ -30,6 +30,7 @@ REQUIRES = [
     "aiohttp-retry >= 2.8.3",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",
+    "pillow >= 9.0.0",
 ]
 
 setup(

--- a/packages/python/tests/test_upload.py
+++ b/packages/python/tests/test_upload.py
@@ -1,0 +1,228 @@
+# Local upload fixtures (no shared server) — the pure-function and guard
+# coverage that, per the parity decision boundary, stays local rather
+# than going through the shared behavior server. Mirrors the kept-local
+# half of the Go/TS upload tests.
+
+import io
+from datetime import datetime, timezone
+
+import pytest
+from PIL import Image, ImageSequence
+
+from yaylib import _image
+from yaylib.upload import (
+    MAX_IMAGES_PER_UPLOAD,
+    MAX_REPORT_IMAGES_PER_UPLOAD,
+    Upload,
+    report_upload,
+    upload_images,
+    upload_single_image,
+    upload_video,
+    user_avatar_upload,
+    user_post_upload,
+    video_call_snapshot_upload,
+)
+
+
+def _jpeg(w, h):
+    b = io.BytesIO()
+    Image.new("RGB", (w, h), (10, 20, 30)).save(b, format="JPEG", quality=75)
+    return b.getvalue()
+
+
+def _png(w, h):
+    b = io.BytesIO()
+    Image.new("RGB", (w, h), (40, 80, 120)).save(b, format="PNG")
+    return b.getvalue()
+
+
+def _gif(w, h, frames=3):
+    # Visually distinct frames so Pillow's GIF encoder doesn't coalesce
+    # them into a single still (which would make the source non-animated
+    # and defeat the point of the test).
+    b = io.BytesIO()
+    imgs = [
+        Image.new("RGB", (w, h), ((i * 60) % 256, 30, (200 - i * 40) % 256)).convert(
+            "P", palette=Image.ADAPTIVE
+        )
+        for i in range(frames)
+    ]
+    imgs[0].save(
+        b, format="GIF", save_all=True, append_images=imgs[1:], duration=80, loop=0
+    )
+    return b.getvalue()
+
+
+# ---- pure helpers ----
+
+
+def test_content_type_for():
+    assert _image.content_type_for("a.png") == "image/png"
+    assert _image.content_type_for("a.gif") == "image/gif"
+    assert _image.content_type_for("a.mp4") == "video/mp4"
+    assert _image.content_type_for("a.jpg") == "image/jpeg"
+    assert _image.content_type_for("a.JPEG") == "image/jpeg"
+    assert _image.content_type_for("a.heic") == "image/jpeg"  # fallback
+    assert _image.content_type_for("noext") == "image/jpeg"
+
+
+def test_normalize_image_ext():
+    assert _image.normalize_image_ext("a.PNG") == ".png"
+    assert _image.normalize_image_ext("a.gif") == ".gif"
+    assert _image.normalize_image_ext("a.jpeg") == ".jpeg"
+    assert _image.normalize_image_ext("a.jpg") == ".jpg"
+    assert _image.normalize_image_ext("a.heic") == ".jpg"
+    assert _image.normalize_image_ext("noext") == ".jpg"
+
+
+def test_image_and_thumbnail_filename_format():
+    assert (
+        _image.image_filename("user/1/avatar", "abc", 1700000000000, 0, ".png", 12, 13)
+        == "user/1/avatar/abc_1700000000000_0_size_12x13.png"
+    )
+    # thumb_ prefix, original dims in the size suffix
+    assert (
+        _image.thumbnail_filename("g/2", "P", 999, 1, ".jpeg", 60, 40)
+        == "g/2/thumb_P_999_1_size_60x40.jpeg"
+    )
+    # empty ext collapses to .jpg; non-positive dims drop the suffix
+    assert _image.image_filename("", "p", 5, 0, "", 0, 0) == "p_5_0.jpg"
+
+
+def test_video_filename_is_flat():
+    assert _image.video_filename("PFX", 12345) == "PFX_12345.mp4"
+
+
+def test_format_ymd_no_zero_padding():
+    d = datetime(2026, 4, 9, tzinfo=timezone.utc)
+    assert _image.format_ymd(d) == "2026/4/9"
+
+
+def test_fit_inside():
+    assert _image.fit_inside(100, 50, 40, 40) == (40, 20)  # aspect preserved
+    assert _image.fit_inside(30, 20, 200, 200) == (30, 20)  # no upscale
+    assert _image.fit_inside(0, 10, 50, 50) == (0, 0)  # invalid
+
+
+def test_random_filename_prefix_length_and_alphabet():
+    p = _image.random_filename_prefix(16)
+    assert len(p) == 16
+    assert all(c.isalnum() and c.isascii() for c in p)
+    assert _image.random_filename_prefix(16) != _image.random_filename_prefix(16)
+
+
+def test_probe_image_size():
+    assert _image.probe_image_size(_jpeg(64, 48)) == (64, 48)
+    assert _image.probe_image_size(_png(12, 13)) == (12, 13)
+    assert _image.probe_image_size(_gif(20, 10)) == (20, 10)
+    with pytest.raises(ValueError, match="decode image"):
+        _image.probe_image_size(b"not an image at all")
+
+
+def test_make_jpeg_thumbnail_shrinks_and_is_jpeg():
+    th = _image.make_thumbnail_for(_png(400, 200), ".png", 100, 100)
+    assert th.ext == ".jpeg" and th.content_type == "image/jpeg"
+    with Image.open(io.BytesIO(th.body)) as im:
+        assert im.format == "JPEG"
+        assert im.size == (100, 50)  # fit inside 100x100, aspect kept
+
+
+def test_make_jpeg_thumbnail_no_upscale():
+    small = _png(20, 10)
+    th = _image.make_thumbnail_for(small, ".png", 200, 200)
+    with Image.open(io.BytesIO(th.body)) as im:
+        assert im.size == (20, 10)  # unchanged, no upscale
+
+
+def test_make_gif_thumbnail_stays_animated_gif():
+    th = _image.make_thumbnail_for(_gif(120, 60, frames=4), ".gif", 40, 40)
+    assert th.ext == ".gif" and th.content_type == "image/gif"
+    with Image.open(io.BytesIO(th.body)) as im:
+        assert im.format == "GIF"
+        assert getattr(im, "is_animated", False)
+        assert im.n_frames == 4
+        assert im.size == (40, 20)
+
+
+def test_make_gif_thumbnail_no_upscale_returns_original_bytes():
+    src = _gif(10, 10, frames=2)
+    th = _image.make_thumbnail_for(src, ".gif", 300, 300)
+    assert th.body == src  # already fits — untouched
+
+
+# ---- categories ----
+
+
+def test_category_paths_and_thumbnail_boxes():
+    now = datetime(2026, 4, 9, tzinfo=timezone.utc)
+    assert user_avatar_upload(42).path(now) == "user/42/avatar"
+    assert user_avatar_upload(42).thumbnail() == (200, 200, True)
+    assert user_post_upload(7).path(now) == "user/7/posts/2026/4/9"
+    snap = video_call_snapshot_upload()
+    assert snap.path(now) == "video_call_snapshot/2026/4/9"
+    assert snap.thumbnail() == (0, 0, False)  # snapshot has no thumbnail
+    assert report_upload().max_files() == MAX_REPORT_IMAGES_PER_UPLOAD
+
+
+# ---- guards (raise before any network) ----
+
+
+class _Deps:
+    """A deps stub whose network methods explode — the guard tests must
+    fail before reaching any of them."""
+
+    def __init__(self, uid=1):
+        self._uid = uid
+
+    def user_id(self):
+        return self._uid
+
+    async def get_presigned_urls(self, file_names):
+        raise AssertionError("network reached; a guard should have fired")
+
+    async def get_video_presigned_url(self, video_file_name):
+        raise AssertionError("network reached; a guard should have fired")
+
+    async def raw_put(self, url, body, content_type):
+        raise AssertionError("network reached; a guard should have fired")
+
+
+async def test_empty_files_rejected():
+    with pytest.raises(ValueError, match="at least one file"):
+        await upload_images(_Deps(), user_avatar_upload(1), [])
+
+
+async def test_overflow_rejected():
+    files = [Upload(filename=f"{i}.jpg", body=_jpeg(4, 4)) for i in range(MAX_IMAGES_PER_UPLOAD + 1)]
+    with pytest.raises(ValueError, match="at most"):
+        await upload_images(_Deps(), user_post_upload(1), files)
+
+
+async def test_report_overflow_rejected():
+    files = [Upload(filename=f"{i}.jpg", body=_jpeg(4, 4)) for i in range(MAX_REPORT_IMAGES_PER_UPLOAD + 1)]
+    with pytest.raises(ValueError, match="at most"):
+        await upload_images(_Deps(), report_upload(), files)
+
+
+async def test_non_image_body_surfaces_error():
+    with pytest.raises(ValueError, match="decode image"):
+        await upload_single_image(
+            _Deps(), user_avatar_upload(1),
+            Upload(filename="broken.jpg", body=b"not an image"),
+        )
+
+
+async def test_upload_video_none_body_rejected():
+    with pytest.raises(ValueError, match="body is None"):
+        await upload_video(_Deps(), None)
+
+
+async def test_upload_requires_login_via_client():
+    from yaylib.client import Client
+
+    c = Client(base_url="http://unused.invalid")
+    try:
+        with pytest.raises(ValueError, match="not logged in"):
+            await c.upload_avatar_image(Upload(filename="a.jpg", body=_jpeg(4, 4)))
+    finally:
+        await c.close()

--- a/packages/python/tests/test_upload_parity.py
+++ b/packages/python/tests/test_upload_parity.py
@@ -1,0 +1,111 @@
+# Upload behavior parity, translated from the Go reference's
+# upload_parity_test.go (and the TS upload_parity.test.ts). Driven
+# against the shared server's upload contract: GET
+# /v1/buckets/presigned_urls returns one server-canonical
+# ("s3/"-prefixed) filename + an in-process S3 URL per requested name;
+# GET /v1/users/presigned_url does the same for video; the S3 receiver
+# answers 200, or 403 if the PUT carries Authorization.
+#
+# The shared S3 receiver intentionally does not echo the Content-Type,
+# the stored bytes, or the file_names[] it saw (behavioral-fidelity
+# only). So the parity assertions are the client-observable ones:
+# success/error, the returned canonical filename shape (the server just
+# prepends "s3/" to the SDK-built name), and the server-enforced
+# no-bearer rule on the presigned PUT. PUT content inspection, image
+# processing, and the pure filename / path / MIME helpers stay as local
+# fixtures in test_upload.py.
+
+import io
+import re
+
+import pytest
+from PIL import Image
+
+from yaylib.retry import RetryPolicy
+from yaylib.upload import Upload
+
+from ._parity import mock_client
+
+# Go's zero-value RetryPolicy{} (retry disabled). The Python default is
+# max_attempts=3, so the presigned-failure case must request "no retry".
+NO_RETRY = RetryPolicy(max_attempts=0, base_delay=0.0, max_delay=0.0)
+
+
+def _jpeg(w: int, h: int) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), (90, 140, 200)).save(buf, format="JPEG", quality=75)
+    return buf.getvalue()
+
+
+def _png(w: int, h: int) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), (30, 90, 160)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+async def test_upload_avatar_image_happy_path():
+    c = mock_client("")
+    c.set_login_identity("", 42)
+    try:
+        name = await c.upload_avatar_image(
+            Upload(filename="me.jpg", body=_jpeg(100, 100))
+        )
+        assert name.startswith("s3/user/42/avatar/"), name
+        assert "_size_100x100" in name, name
+    finally:
+        await c.close()
+
+
+async def test_upload_avatar_image_filename_shape():
+    c = mock_client("")
+    c.set_login_identity("", 1)
+    try:
+        name = await c.upload_avatar_image(
+            Upload(filename="x.png", body=_png(12, 13))
+        )
+        assert re.match(
+            r"^s3/user/1/avatar/[0-9A-Za-z]{16}_\d{13}_0_size_12x13\.png$", name
+        ), name
+    finally:
+        await c.close()
+
+
+async def test_upload_avatar_image_presigned_failure():
+    # fail-503-times-1 makes the first request in the session — the
+    # presigned-URL GET — fail; with retry disabled the upload errors.
+    c = mock_client("fail-503-times-1", retry_policy=NO_RETRY)
+    c.set_login_identity("", 1)
+    try:
+        with pytest.raises(Exception):
+            await c.upload_avatar_image(
+                Upload(filename="a.png", body=_png(5, 5))
+            )
+    finally:
+        await c.close()
+
+
+async def test_upload_video_happy_path():
+    c = mock_client("")
+    try:
+        name = await c.upload_video(b"\x00\x00\x00 ftypisom--mp4-bytes--")
+        assert name.endswith(".mp4"), name
+    finally:
+        await c.close()
+
+
+async def test_presigned_put_does_not_leak_bearer():
+    # Tokens are set, but the presigned PUT must authenticate via the
+    # signed query only. The shared S3 receiver answers 403 if the PUT
+    # carries Authorization, so a successful upload proves no bearer
+    # leaked — the check is server-enforced and identical across the
+    # three languages.
+    c = mock_client("")
+    c.set_login_identity("", 1)
+    c.set_tokens("SECRET-ACCESS-TOKEN", "REF")
+    try:
+        name = await c.upload_avatar_image(
+            Upload(filename="x.png", body=_png(5, 5))
+        )
+        assert name.startswith("s3/user/1/avatar/"), name
+    finally:
+        await c.close()

--- a/packages/python/yaylib/_image.py
+++ b/packages/python/yaylib/_image.py
@@ -1,0 +1,226 @@
+"""PORTING.md §8: the upload-protocol pieces that aren't visible from the
+category table — filename shaping, source-size probing, and the thumbnail
+rules. The Yay! server pattern-matches the filenames and DELETES the main
+image if its thumbnail is missing, statically encoded, or
+extension-mismatched, so this module mirrors upload.go / image.ts exactly:
+JPEG/PNG sources produce a shrunk JPEG thumbnail, animated GIF sources
+stay animated through the resize.
+"""
+
+from __future__ import annotations
+
+import io
+import secrets
+import time
+from datetime import datetime, timezone
+from typing import Tuple
+
+from PIL import Image, ImageSequence
+
+# Default per-call cap on multi-image uploads (upload_post_images,
+# upload_chat_message_images). upload_report_images is tighter.
+MAX_IMAGES_PER_UPLOAD = 9
+
+# Per-call cap on upload_report_images (the server rejects the 5th).
+MAX_REPORT_IMAGES_PER_UPLOAD = 4
+
+_PREFIX_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def ext_of(filename: str) -> str:
+    """Lowercased extension including the leading dot, or "" when the
+    filename has no extension. Mirrors Go's filepath.Ext semantics."""
+    base = filename[filename.rfind("/") + 1 :]
+    dot = base.rfind(".")
+    if dot <= 0:
+        return ""
+    return base[dot:].lower()
+
+
+def content_type_for(filename: str) -> str:
+    """Map a filename extension to the Content-Type sent on the presigned
+    PUT. Unknown extensions fall back to image/jpeg."""
+    return {
+        ".png": "image/png",
+        ".gif": "image/gif",
+        ".mp4": "video/mp4",
+    }.get(ext_of(filename), "image/jpeg")
+
+
+def normalize_image_ext(filename: str) -> str:
+    """Collapse any input filename to one of .jpg, .jpeg, .png, .gif.
+    Anything else becomes .jpg, matching upload.go."""
+    e = ext_of(filename)
+    return e if e in (".png", ".gif", ".jpeg", ".jpg") else ".jpg"
+
+
+def _size_suffix(width: int, height: int) -> str:
+    return f"_size_{width}x{height}" if width > 0 and height > 0 else ""
+
+
+def image_filename(
+    category_path: str,
+    prefix: str,
+    unix_millis: int,
+    index: int,
+    ext: str,
+    width: int,
+    height: int,
+) -> str:
+    """Main-image object key the Yay! server pattern-matches. Empty ext
+    collapses to .jpg; the size suffix is omitted when either dimension
+    is non-positive."""
+    e = ext or ".jpg"
+    body = f"{prefix}_{unix_millis}_{index}{_size_suffix(width, height)}{e}"
+    return body if category_path == "" else f"{category_path}/{body}"
+
+
+def thumbnail_filename(
+    category_path: str,
+    prefix: str,
+    unix_millis: int,
+    index: int,
+    ext: str,
+    orig_width: int,
+    orig_height: int,
+) -> str:
+    """Like image_filename but with the "thumb_" prefix the server
+    expects for the resized companion. The size suffix carries the
+    *original* image dimensions, not the thumbnail's."""
+    e = ext or ".jpg"
+    body = f"thumb_{prefix}_{unix_millis}_{index}{_size_suffix(orig_width, orig_height)}{e}"
+    return body if category_path == "" else f"{category_path}/{body}"
+
+
+def video_filename(prefix: str, unix_millis: int) -> str:
+    """The flat key videos use — no category path, no size suffix."""
+    return f"{prefix}_{unix_millis}.mp4"
+
+
+def random_filename_prefix(n: int) -> str:
+    """n characters from [0-9A-Za-z], freshly generated per upload call.
+    upload.go panics rather than fabricate a fixed prefix that would
+    guarantee bucket collisions; secrets is always available here."""
+    return "".join(secrets.choice(_PREFIX_ALPHABET) for _ in range(n))
+
+
+def now_unix_millis() -> int:
+    return int(time.time() * 1000)
+
+
+def format_ymd(d: datetime) -> str:
+    """"YYYY/M/D" with un-padded month and day. UTC fields make the
+    bucket path deterministic regardless of host timezone (PORTING.md
+    §8: the server treats the path as a hint)."""
+    u = d.astimezone(timezone.utc)
+    return f"{u.year}/{u.month}/{u.day}"
+
+
+def fit_inside(src_w: int, src_h: int, max_w: int, max_h: int) -> Tuple[int, int]:
+    """Width/height that fit src_w x src_h inside max_w x max_h while
+    preserving aspect ratio. Sources already smaller than the box are
+    returned unchanged. (0, 0) signals invalid input."""
+    if src_w <= 0 or src_h <= 0:
+        return (0, 0)
+    scale = 1.0
+    scale = min(scale, max_w / src_w)
+    scale = min(scale, max_h / src_h)
+    dst_w = max(1, int(src_w * scale))
+    dst_h = max(1, int(src_h * scale))
+    return (dst_w, dst_h)
+
+
+def probe_image_size(body: bytes) -> Tuple[int, int]:
+    """Native (width, height) of a JPEG, PNG, or GIF. An undecodable
+    body raises — uploading a body whose size suffix is wrong (or whose
+    required thumbnail can't be built) just triggers server-side
+    moderation deletion, so we surface the failure."""
+    try:
+        with Image.open(io.BytesIO(body)) as im:
+            w, h = im.size
+    except Exception as err:  # noqa: BLE001
+        raise ValueError(f"decode image: {err}") from err
+    if w <= 0 or h <= 0:
+        raise ValueError("decode image: could not read dimensions")
+    return (w, h)
+
+
+class Thumbnail:
+    __slots__ = ("body", "ext", "content_type")
+
+    def __init__(self, body: bytes, ext: str, content_type: str) -> None:
+        self.body = body
+        self.ext = ext
+        self.content_type = content_type
+
+
+def make_thumbnail_for(
+    body: bytes, source_ext: str, max_w: int, max_h: int
+) -> Thumbnail:
+    """The right kind of thumbnail for the source format. GIF inputs stay
+    animated GIFs (so the avatar/icon keeps moving when the server
+    renders the thumbnail); everything else becomes a JPEG. The returned
+    ext/content_type match the produced bytes, mirroring upload.go."""
+    if source_ext == ".gif":
+        return Thumbnail(_make_gif_thumbnail(body, max_w, max_h), ".gif", "image/gif")
+    return Thumbnail(_make_jpeg_thumbnail(body, max_w, max_h), ".jpeg", "image/jpeg")
+
+
+def _make_jpeg_thumbnail(body: bytes, max_w: int, max_h: int) -> bytes:
+    if max_w <= 0 or max_h <= 0:
+        raise ValueError(f"make thumbnail: invalid target size {max_w}x{max_h}")
+    try:
+        with Image.open(io.BytesIO(body)) as im:
+            im = im.convert("RGB")
+            sw, sh = im.size
+            dst_w, dst_h = fit_inside(sw, sh, max_w, max_h)
+            if dst_w == 0:
+                raise ValueError("make thumbnail: empty source image")
+            if (dst_w, dst_h) != (sw, sh):
+                im = im.resize((dst_w, dst_h), Image.BILINEAR)
+            out = io.BytesIO()
+            im.save(out, format="JPEG", quality=85)
+            return out.getvalue()
+    except ValueError:
+        raise
+    except Exception as err:  # noqa: BLE001
+        raise ValueError(f"make thumbnail: decode source image: {err}") from err
+
+
+def _make_gif_thumbnail(body: bytes, max_w: int, max_h: int) -> bytes:
+    if max_w <= 0 or max_h <= 0:
+        raise ValueError(f"make thumbnail: invalid target size {max_w}x{max_h}")
+    try:
+        src = Image.open(io.BytesIO(body))
+    except Exception as err:  # noqa: BLE001
+        raise ValueError(f"make thumbnail: decode gif: {err}") from err
+    sw, sh = src.size
+    dst_w, dst_h = fit_inside(sw, sh, max_w, max_h)
+    if dst_w == 0:
+        raise ValueError("make thumbnail: empty gif")
+    if (dst_w, dst_h) == (sw, sh):
+        # Already fits — return the original bytes untouched (upload.go).
+        return body
+
+    frames = []
+    durations = []
+    for frame in ImageSequence.Iterator(src):
+        # Compositing onto a full RGBA canvas before scaling mirrors the
+        # full-canvas invariant upload.go establishes.
+        rgba = frame.convert("RGBA")
+        durations.append(frame.info.get("duration", src.info.get("duration", 0)))
+        frames.append(rgba.resize((dst_w, dst_h), Image.BILINEAR).convert("P", palette=Image.ADAPTIVE))
+
+    out = io.BytesIO()
+    loop = src.info.get("loop", 0)
+    frames[0].save(
+        out,
+        format="GIF",
+        save_all=True,
+        append_images=frames[1:],
+        loop=loop if isinstance(loop, int) and loop >= 0 else 0,
+        duration=durations,
+        disposal=2,
+        optimize=False,
+    )
+    return out.getvalue()

--- a/packages/python/yaylib/client.py
+++ b/packages/python/yaylib/client.py
@@ -13,7 +13,9 @@ import contextlib
 import json
 import logging
 import uuid as _uuid
-from typing import Optional
+from typing import List, Optional
+
+import yaylib.upload as _upload
 from urllib.parse import urlencode
 
 from yaylib.api.activities_api import ActivitiesApi
@@ -289,6 +291,105 @@ class Client:
         self._bg_tasks.clear()
         await self._transport.close()
 
+    # ---- uploads (PORTING.md §8) ----
+
+    def _upload_deps(self) -> "_UploadDeps":
+        return _UploadDeps(self)
+
+    def _require_user_id(self) -> int:
+        if not self._user_id:
+            raise ValueError(
+                "yaylib: not logged in (call login_with_email before "
+                "user-bound uploads)"
+            )
+        return self._user_id
+
+    async def upload_avatar_image(self, file: _upload.Upload) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(),
+            _upload.user_avatar_upload(self._require_user_id()),
+            file,
+        )
+
+    async def upload_cover_image(self, file: _upload.Upload) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(),
+            _upload.user_cover_upload(self._require_user_id()),
+            file,
+        )
+
+    async def upload_post_images(self, files: List[_upload.Upload]) -> List[str]:
+        return await _upload.upload_images(
+            self._upload_deps(),
+            _upload.user_post_upload(self._require_user_id()),
+            files,
+        )
+
+    async def upload_chat_message_images(
+        self, room_id: int, files: List[_upload.Upload]
+    ) -> List[str]:
+        return await _upload.upload_images(
+            self._upload_deps(),
+            _upload.chat_message_upload(room_id, self._require_user_id()),
+            files,
+        )
+
+    async def upload_chat_background_image(
+        self, room_id: int, file: _upload.Upload
+    ) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(), _upload.chat_background_upload(room_id), file
+        )
+
+    async def upload_group_icon_image(
+        self, group_id: int, file: _upload.Upload
+    ) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(), _upload.group_icon_upload(group_id), file
+        )
+
+    async def upload_group_cover_image(
+        self, group_id: int, file: _upload.Upload
+    ) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(), _upload.group_cover_upload(group_id), file
+        )
+
+    async def upload_group_creation_icon_image(self, file: _upload.Upload) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(), _upload.group_creation_icon_upload(), file
+        )
+
+    async def upload_group_creation_cover_image(self, file: _upload.Upload) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(), _upload.group_creation_cover_upload(), file
+        )
+
+    async def upload_signup_avatar_image(self, file: _upload.Upload) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(), _upload.signup_avatar_upload(), file
+        )
+
+    async def upload_thread_icon_image(
+        self, group_id: int, file: _upload.Upload
+    ) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(), _upload.thread_icon_upload(group_id), file
+        )
+
+    async def upload_report_images(self, files: List[_upload.Upload]) -> List[str]:
+        return await _upload.upload_images(
+            self._upload_deps(), _upload.report_upload(), files
+        )
+
+    async def upload_video_call_snapshot_image(self, file: _upload.Upload) -> str:
+        return await _upload.upload_single_image(
+            self._upload_deps(), _upload.video_call_snapshot_upload(), file
+        )
+
+    async def upload_video(self, body) -> str:
+        return await _upload.upload_video(self._upload_deps(), body)
+
     # ---- lazy X-Client-IP (PORTING.md §12) ----
 
     def _maybe_fetch_client_ip(self) -> None:
@@ -446,3 +547,43 @@ class Client:
                 )
 
         return True
+
+
+class _UploadDeps:
+    """Adapter implementing upload.UploadDeps over a Client.
+
+    The presigned-URL fetch goes through the wrapped generated client so
+    it carries auth + retry; the PUT goes through the transport's
+    UNWRAPPED round-trip so it never carries a Bearer and never recurses
+    into the refresh/retry hook (PORTING.md §6.1 / §8).
+    """
+
+    __slots__ = ("_c",)
+
+    def __init__(self, client: "Client") -> None:
+        self._c = client
+
+    def user_id(self) -> int:
+        return self._c._user_id
+
+    async def get_presigned_urls(self, file_names):
+        resp = await self._c.buckets_api.get_bucket_presigned_urls(
+            file_names=file_names
+        )
+        return resp.presigned_urls or []
+
+    async def get_video_presigned_url(self, video_file_name: str) -> str:
+        resp = await self._c.users_api.get_user_presigned_url(
+            video_file_name=video_file_name
+        )
+        return resp.presigned_url or ""
+
+    async def raw_put(self, url: str, body: bytes, content_type: str) -> None:
+        res = await self._c._transport.send_unwrapped(
+            "PUT", url, {"Content-Type": content_type}, body
+        )
+        if not (200 <= res.status <= 299):
+            preview = ""
+            if res.data:
+                preview = res.data[:512].decode("utf-8", "replace").strip()
+            raise ValueError(f"PUT {res.status}: {preview}")

--- a/packages/python/yaylib/upload.py
+++ b/packages/python/yaylib/upload.py
@@ -1,0 +1,327 @@
+"""PORTING.md §8: the typed upload categories + upload_video. The category
+table (method <-> bucket path <-> thumbnail size <-> file cap) lives here;
+the filename shaping, the s3/ canonical-name contract and the animated-GIF
+thumbnail rule live in _image.py.
+
+The presigned PUT bypasses the wrapped client entirely (the transport's
+Yay! headers / Bearer would conflict with the presigned URL's own
+signature), exactly as upload.go routes it through the bare client. The
+presigned-URL fetch and the ws-token fetch still go through the wrapped
+client so they carry auth + retry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, List, Optional, Protocol, Tuple, Union
+
+from yaylib._image import (
+    MAX_IMAGES_PER_UPLOAD,
+    MAX_REPORT_IMAGES_PER_UPLOAD,
+    content_type_for,
+    format_ymd,
+    image_filename,
+    make_thumbnail_for,
+    normalize_image_ext,
+    now_unix_millis,
+    probe_image_size,
+    random_filename_prefix,
+    thumbnail_filename,
+    video_filename,
+)
+
+__all__ = [
+    "Upload",
+    "UploadCategory",
+    "MAX_IMAGES_PER_UPLOAD",
+    "MAX_REPORT_IMAGES_PER_UPLOAD",
+    "user_avatar_upload",
+    "user_cover_upload",
+    "user_post_upload",
+    "chat_message_upload",
+    "chat_background_upload",
+    "group_icon_upload",
+    "group_cover_upload",
+    "group_creation_icon_upload",
+    "group_creation_cover_upload",
+    "signup_avatar_upload",
+    "thread_icon_upload",
+    "report_upload",
+    "video_call_snapshot_upload",
+]
+
+_DEFAULT_MAX_FILES = MAX_IMAGES_PER_UPLOAD
+
+# A file body is raw bytes or any object exposing a .read() -> bytes.
+Body = Union[bytes, bytearray, "SupportsRead"]
+
+
+class SupportsRead(Protocol):
+    def read(self) -> bytes: ...
+
+
+@dataclass
+class Upload:
+    """A single file passed to one of the upload_<xxx>_image[s] methods.
+    ``filename`` derives the extension and Content-Type; ``body`` is
+    buffered fully before the request is issued."""
+
+    filename: str
+    body: Body
+
+
+def _to_bytes(body: Body) -> bytes:
+    if isinstance(body, (bytes, bytearray)):
+        return bytes(body)
+    return bytes(body.read())
+
+
+class UploadCategory:
+    """Selects the bucket-side path prefix, the thumbnail box, and the
+    per-call file cap."""
+
+    __slots__ = ("path", "thumbnail", "max_files")
+
+    def __init__(
+        self,
+        path: Callable[[datetime], str],
+        thumbnail: Callable[[], Tuple[int, int, bool]],
+        max_files: Callable[[], int],
+    ) -> None:
+        self.path = path
+        self.thumbnail = thumbnail
+        self.max_files = max_files
+
+
+def _cat(
+    path: Callable[[datetime], str],
+    thumb: Tuple[int, int, bool],
+    max_files: int = _DEFAULT_MAX_FILES,
+) -> UploadCategory:
+    return UploadCategory(path, lambda: thumb, lambda: max_files)
+
+
+def user_avatar_upload(user_id: int) -> UploadCategory:
+    return _cat(lambda _n: f"user/{user_id}/avatar", (200, 200, True))
+
+
+def user_cover_upload(user_id: int) -> UploadCategory:
+    return _cat(lambda _n: f"user/{user_id}/cover", (300, 150, True))
+
+
+def user_post_upload(user_id: int) -> UploadCategory:
+    return _cat(lambda n: f"user/{user_id}/posts/{format_ymd(n)}", (450, 450, True))
+
+
+def chat_message_upload(room_id: int, user_id: int) -> UploadCategory:
+    return _cat(
+        lambda n: f"chatroom/{room_id}/user/{user_id}/messages/{format_ymd(n)}",
+        (450, 450, True),
+    )
+
+
+def chat_background_upload(room_id: int) -> UploadCategory:
+    return _cat(lambda _n: f"chatroom/{room_id}/background", (200, 200, True))
+
+
+def group_icon_upload(group_id: int) -> UploadCategory:
+    return _cat(lambda _n: f"group/{group_id}/icon", (300, 300, True))
+
+
+def group_cover_upload(group_id: int) -> UploadCategory:
+    return _cat(lambda _n: f"group/{group_id}/cover", (300, 300, True))
+
+
+def group_creation_icon_upload() -> UploadCategory:
+    return _cat(lambda n: f"group/create/icon/{format_ymd(n)}", (300, 300, True))
+
+
+def group_creation_cover_upload() -> UploadCategory:
+    return _cat(lambda n: f"group/create/cover/{format_ymd(n)}", (300, 300, True))
+
+
+def signup_avatar_upload() -> UploadCategory:
+    return _cat(lambda n: f"user/create/{format_ymd(n)}", (200, 200, True))
+
+
+def thread_icon_upload(group_id: int) -> UploadCategory:
+    return _cat(lambda n: f"group/{group_id}/threads/{format_ymd(n)}", (300, 300, True))
+
+
+def report_upload() -> UploadCategory:
+    return _cat(
+        lambda n: f"report/{format_ymd(n)}",
+        (450, 450, True),
+        MAX_REPORT_IMAGES_PER_UPLOAD,
+    )
+
+
+def video_call_snapshot_upload() -> UploadCategory:
+    return _cat(lambda n: f"video_call_snapshot/{format_ymd(n)}", (0, 0, False))
+
+
+class _PresignedURL(Protocol):
+    filename: Optional[str]
+    url: Optional[str]
+
+
+class UploadDeps(Protocol):
+    """The slice of Client behaviour the upload core needs. The Client
+    supplies it; keeping it abstract avoids a client <-> upload import
+    cycle and makes the flow unit-testable."""
+
+    def user_id(self) -> int: ...
+
+    async def get_presigned_urls(
+        self, file_names: List[str]
+    ) -> List[_PresignedURL]: ...
+
+    async def get_video_presigned_url(self, video_file_name: str) -> str: ...
+
+    # raw_put bypasses the wrapped client — see the module header. Raises
+    # on a non-2xx response or transport error.
+    async def raw_put(self, url: str, body: bytes, content_type: str) -> None: ...
+
+
+def require_user_id(deps: UploadDeps) -> int:
+    uid = deps.user_id()
+    if not uid:
+        raise ValueError(
+            "yaylib: not logged in (call login_with_email before user-bound uploads)"
+        )
+    return uid
+
+
+class _Job:
+    __slots__ = ("body", "filename", "content_type")
+
+    def __init__(self, body: bytes, filename: str, content_type: str) -> None:
+        self.body = body
+        self.filename = filename
+        self.content_type = content_type
+
+
+async def upload_images(
+    deps: UploadDeps, category: UploadCategory, files: List[Upload]
+) -> List[str]:
+    """The full presigned-URL + parallel-PUT dance shared by every
+    image-upload method, mirroring upload.go's uploadImages. The returned
+    names are the server-canonical (s3/-prefixed) main-image names;
+    thumbnails live at sibling paths the server resolves automatically."""
+    if category is None:
+        raise ValueError("yaylib: upload requires a category")
+    if not files:
+        raise ValueError("yaylib: upload requires at least one file")
+    cap = category.max_files()
+    if len(files) > cap:
+        raise ValueError(
+            f"yaylib: this upload accepts at most {cap} files (got {len(files)})"
+        )
+
+    now = datetime.now(timezone.utc)
+    prefix = random_filename_prefix(16)
+    ts = now_unix_millis()
+    category_path = category.path(now)
+    thumb_w, thumb_h, has_thumb = category.thumbnail()
+
+    main_jobs: List[_Job] = []
+    thumb_jobs: List[_Job] = []
+
+    for i, f in enumerate(files):
+        try:
+            body = _to_bytes(f.body)
+        except Exception as err:  # noqa: BLE001
+            raise ValueError(f"yaylib: read file {i}: {err}") from err
+        ext = normalize_image_ext(f.filename)
+        # A failed decode means the size suffix would be wrong and the
+        # body can't be thumbnailed; uploading it anyway just triggers
+        # server-side moderation deletion, so surface the error.
+        try:
+            w, h = probe_image_size(body)
+        except Exception as err:  # noqa: BLE001
+            raise ValueError(f"yaylib: decode image {i}: {err}") from err
+        main_name = image_filename(category_path, prefix, ts, i, ext, w, h)
+        main_jobs.append(_Job(body, main_name, content_type_for(main_name)))
+
+        if has_thumb:
+            try:
+                thumb = make_thumbnail_for(body, ext, thumb_w, thumb_h)
+            except Exception as err:  # noqa: BLE001
+                # A missing/mismatched thumbnail makes the server delete
+                # the main asset too, so fail loudly.
+                raise ValueError(
+                    f"yaylib: make thumbnail for image {i}: {err}"
+                ) from err
+            thumb_name = thumbnail_filename(
+                category_path, prefix, ts, i, thumb.ext, w, h
+            )
+            thumb_jobs.append(_Job(thumb.body, thumb_name, thumb.content_type))
+
+    all_jobs = main_jobs + thumb_jobs
+    all_file_names = [j.filename for j in all_jobs]
+
+    try:
+        urls = await deps.get_presigned_urls(all_file_names)
+    except Exception as err:  # noqa: BLE001
+        raise ValueError(f"yaylib: get presigned urls: {err}") from err
+    if len(urls) != len(all_jobs):
+        raise ValueError(
+            f"yaylib: presigned urls count mismatch "
+            f"(want {len(all_jobs)} got {len(urls)})"
+        )
+
+    async def _put(job: _Job, raw_url: str) -> None:
+        if not raw_url:
+            raise ValueError(f"yaylib: upload {job.filename}: empty presigned url")
+        try:
+            await deps.raw_put(raw_url, job.body, job.content_type)
+        except ValueError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            raise ValueError(f"yaylib: upload {job.filename}: {err}") from err
+
+    results = await asyncio.gather(
+        *[_put(job, urls[i].url or "") for i, job in enumerate(all_jobs)],
+        return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, BaseException):
+            raise r
+
+    # The server normalizes each filename (typically an "s3/" prefix
+    # marking it as a freshly-uploaded object). That canonical value —
+    # not the client-side path — is what edit_user / create_post expect.
+    return [urls[i].filename or "" for i in range(len(files))]
+
+
+async def upload_single_image(
+    deps: UploadDeps, category: UploadCategory, file: Upload
+) -> str:
+    names = await upload_images(deps, category, [file])
+    return names[0]
+
+
+async def upload_video(deps: UploadDeps, body: Optional[Body]) -> str:
+    """Upload a single MP4 stream and return the filename to pass back as
+    video_file_name. The video presigned endpoint does not return a
+    canonical filename, so the random name the SDK generates is what
+    callers hand to create_post / send_chat_message (PORTING.md §8)."""
+    if body is None:
+        raise ValueError("yaylib: upload_video: body is None")
+    data = _to_bytes(body)
+    name = video_filename(random_filename_prefix(16), now_unix_millis())
+
+    try:
+        raw_url = await deps.get_video_presigned_url(name)
+    except Exception as err:  # noqa: BLE001
+        raise ValueError(f"yaylib: get presigned url: {err}") from err
+    if not raw_url:
+        raise ValueError("yaylib: empty presigned url")
+
+    try:
+        await deps.raw_put(raw_url, data, "video/mp4")
+    except Exception as err:  # noqa: BLE001
+        raise ValueError(f"yaylib: upload video: {err}") from err
+    return name


### PR DESCRIPTION
Ports the upload contract (PORTING.md §8) to the Python SDK, which previously had no upload support.

## What

- `_image.py` — filename shaping, content-type, source-size probing, JPEG + animated-GIF thumbnails (via Pillow)
- `upload.py` — the 13 typed upload categories, `upload_video`, and the presigned-URL / parallel-PUT orchestration
- `Client` — 14 `upload_*` methods; the presigned PUT uses the unwrapped transport (no bearer, no refresh/retry recursion)
- Pillow added as a dependency
- `tests/test_upload_parity.py` — same scenarios as the Go / TS upload parity suites against the shared behavior server
- `tests/test_upload.py` — pure-function and guard coverage (kept local)

## Verification

- Python standalone: `73 passed, 24 skipped` (parity skips without the server)
- Full 3-language parity against one shared server: Go `ok`, Python venv `97 passed`, TS `226 PASS` (exit 0)
- upload behavior parity now complete across Go / TS / Python