### PR TITLE
fix(python): tolerate server-added enum values

### DIFF
--- a/packages/python/yaylib/models/j0_a.py
+++ b/packages/python/yaylib/models/j0_a.py
@@ -31,6 +31,14 @@ class J0A(str, Enum):
     GROUPTIMELINE = 'GroupTimeline'
 
     @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        # Accept any string the server sends, not only the values
+        # enumerated above, so a value added server-side still
+        # decodes. The typed constants stay usable for comparisons.
+        from pydantic_core import core_schema
+        return core_schema.str_schema()
+
+    @classmethod
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of J0A from a JSON string"""
         return cls(json.loads(json_str))

--- a/packages/python/yaylib/models/message_type.py
+++ b/packages/python/yaylib/models/message_type.py
@@ -41,6 +41,14 @@ class MessageType(str, Enum):
     OWNER_KICK = 'owner_kick'
 
     @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        # Accept any string the server sends, not only the values
+        # enumerated above, so a value added server-side still
+        # decodes. The typed constants stay usable for comparisons.
+        from pydantic_core import core_schema
+        return core_schema.str_schema()
+
+    @classmethod
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of MessageType from a JSON string"""
         return cls(json.loads(json_str))

--- a/packages/python/yaylib/models/mission_type.py
+++ b/packages/python/yaylib/models/mission_type.py
@@ -32,6 +32,14 @@ class MissionType(str, Enum):
     ONCE = 'once'
 
     @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        # Accept any string the server sends, not only the values
+        # enumerated above, so a value added server-side still
+        # decodes. The typed constants stay usable for comparisons.
+        from pydantic_core import core_schema
+        return core_schema.str_schema()
+
+    @classmethod
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of MissionType from a JSON string"""
         return cls(json.loads(json_str))

--- a/packages/python/yaylib/models/noreply_mode.py
+++ b/packages/python/yaylib/models/noreply_mode.py
@@ -30,6 +30,14 @@ class NoreplyMode(str, Enum):
     NOREPLY = 'noreply_'
 
     @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        # Accept any string the server sends, not only the values
+        # enumerated above, so a value added server-side still
+        # decodes. The typed constants stay usable for comparisons.
+        from pydantic_core import core_schema
+        return core_schema.str_schema()
+
+    @classmethod
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of NoreplyMode from a JSON string"""
         return cls(json.loads(json_str))

--- a/packages/python/yaylib/models/online_status_enum.py
+++ b/packages/python/yaylib/models/online_status_enum.py
@@ -30,6 +30,14 @@ class OnlineStatusEnum(str, Enum):
     HIDDEN = 'hidden'
 
     @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        # Accept any string the server sends, not only the values
+        # enumerated above, so a value added server-side still
+        # decodes. The typed constants stay usable for comparisons.
+        from pydantic_core import core_schema
+        return core_schema.str_schema()
+
+    @classmethod
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of OnlineStatusEnum from a JSON string"""
         return cls(json.loads(json_str))

--- a/packages/python/yaylib/models/pal_grade.py
+++ b/packages/python/yaylib/models/pal_grade.py
@@ -32,6 +32,14 @@ class PalGrade(str, Enum):
     ULTIMATE_PAL = 'Ultimate Pal'
 
     @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        # Accept any string the server sends, not only the values
+        # enumerated above, so a value added server-side still
+        # decodes. The typed constants stay usable for comparisons.
+        from pydantic_core import core_schema
+        return core_schema.str_schema()
+
+    @classmethod
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of PalGrade from a JSON string"""
         return cls(json.loads(json_str))

--- a/packages/python/yaylib/models/post_type.py
+++ b/packages/python/yaylib/models/post_type.py
@@ -41,6 +41,14 @@ class PostType(str, Enum):
     TEXT = 'text'
 
     @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        # Accept any string the server sends, not only the values
+        # enumerated above, so a value added server-side still
+        # decodes. The typed constants stay usable for comparisons.
+        from pydantic_core import core_schema
+        return core_schema.str_schema()
+
+    @classmethod
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of PostType from a JSON string"""
         return cls(json.loads(json_str))


### PR DESCRIPTION
The generated string enums were validated strictly by pydantic, so any value the server sends outside the enumerated set failed to decode an otherwise-valid response (e.g. an `online_status` the API added after the models were generated).

Each generated str-enum now exposes `__get_pydantic_core_schema__` returning a plain string schema, so the field validates as a string and the strict membership check is skipped. The `(str, Enum)` class, its typed constants and `from_json` are unchanged, so `OnlineStatusEnum.OFFLINE == "offline"` still holds both directions and known values are unaffected.

This brings the Python client in line with the Go and TypeScript clients, which already pass unknown enum values through rather than rejecting the whole response.

Verification: full Python suite **97 passed** under the shared mock server (73 passed / 24 mock-gated skipped standalone); the captured real-wire snapshots that previously failed Python decode now all decode.