### PR TITLE
fix(python): accept any 2xx status, not only the documented one

### DIFF
--- a/packages/python/yaylib/api_client.py
+++ b/packages/python/yaylib/api_client.py
@@ -304,6 +304,23 @@ class ApiClient:
             # if not found, look for '1XX', '2XX', etc.
             response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
+        # The server uses 2xx codes the schema did not enumerate
+        # (e.g. 201 on a successful login); fall back to the single
+        # documented success type instead of discarding the body, the
+        # same way the other language clients accept any 2xx.
+        if (
+            not response_type
+            and isinstance(response_data.status, int)
+            and 200 <= response_data.status <= 299
+            and response_types_map
+        ):
+            _success = {
+                v for k, v in response_types_map.items()
+                if v is not None and k[:1] == "2"
+            }
+            if len(_success) == 1:
+                response_type = next(iter(_success))
+
         # deserialize response data
         response_text = None
         return_data = None


### PR DESCRIPTION
Response deserialization looked up the response type by the exact documented status code (the per-operation map is `{'200': "LoginUserResponse"}`). The server answers some successful calls with a different 2xx — **login returns `201`** — so the generated client found no type, discarded a perfectly valid body and returned `None` (a live login could not complete).

When the exact-status and `NXX` lookups both miss but the status is in `200..299` and exactly one success type is documented, fall back to that type. Already-mapped statuses are unaffected; an ambiguous multi-type 2xx map is left untouched.

This brings the Python client in line with the Go and TypeScript clients, which already treat any 2xx response as the success body.

Verification: live login (HTTP 201) now decodes; Python suite **97 passed** under the shared mock server (73 passed / 24 mock-gated skipped standalone), no regression.