### PR TITLE
test: complete §15 behavior-parity coverage (Go/TS/Python)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@ error_codes.go linguist-generated=true
 host_routes.go linguist-generated=true
 
 packages/typescript/src/gen/** linguist-generated=true
+packages/typescript/src/error_codes.ts linguist-generated=true
 
 packages/python/yaylib/models/** linguist-generated=true
 packages/python/yaylib/api/** linguist-generated=true
@@ -19,3 +20,4 @@ packages/python/yaylib/configuration.py linguist-generated=true
 packages/python/yaylib/exceptions.py linguist-generated=true
 packages/python/yaylib/rest.py linguist-generated=true
 packages/python/yaylib/_host_routes.py linguist-generated=true
+packages/python/yaylib/_error_codes.py linguist-generated=true

--- a/enum_tolerance_test.go
+++ b/enum_tolerance_test.go
@@ -1,0 +1,37 @@
+package yaylib
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ekkx/yaylib/v2/gen"
+)
+
+// Enum-typed fields are decoded leniently: a value the SDK does not
+// know about is still accepted and kept verbatim on the typed field
+// (no decode error), so a server that adds a new variant does not
+// break older clients. IsValid() reports false for such a value, and
+// the named constants stay usable for the values the SDK does know.
+func TestUnknownEnumValueIsAccepted(t *testing.T) {
+	var p gen.Post
+	if err := json.Unmarshal([]byte(`{"post_type":"__mock_unknown_enum__"}`), &p); err != nil {
+		t.Fatalf("unknown enum value: unmarshal failed: %v", err)
+	}
+	if got := string(p.GetPostType()); got != "__mock_unknown_enum__" {
+		t.Fatalf("GetPostType() = %q, want %q", got, "__mock_unknown_enum__")
+	}
+	if p.GetPostType().IsValid() {
+		t.Fatalf("IsValid() = true for unknown value, want false")
+	}
+
+	var known gen.Post
+	if err := json.Unmarshal([]byte(`{"post_type":"image"}`), &known); err != nil {
+		t.Fatalf("known enum value: unmarshal failed: %v", err)
+	}
+	if got := known.GetPostType(); got != gen.POSTTYPE_Image {
+		t.Fatalf("GetPostType() = %q, want %q", got, gen.POSTTYPE_Image)
+	}
+	if !known.GetPostType().IsValid() {
+		t.Fatalf("IsValid() = false for known value, want true")
+	}
+}

--- a/execute_raw_parity_test.go
+++ b/execute_raw_parity_test.go
@@ -1,0 +1,47 @@
+package yaylib
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// ExecuteRaw parity, driven against the shared server's
+// body-malformed contract: the endpoint answers HTTP 200 with a JSON
+// scalar no typed model can decode. The typed Execute() path must
+// surface that as an *APIError carrying the raw body, while the
+// sibling ExecuteRaw() path must hand back the unparsed bytes and the
+// successful response untouched — the per-call escape hatch for
+// production wire that the typed decoder cannot absorb. The contract
+// is server-enforced and identical across the three languages; the
+// test auto-skips when the shared server is not configured.
+func TestExecuteRaw_AbsorbsTypedDecodeFailure(t *testing.T) {
+	c := mockClient(t, "body-malformed")
+	ctx := context.Background()
+
+	if _, _, err := c.GetBucketPresignedUrls(ctx).Execute(); err == nil {
+		t.Fatal("typed Execute() on malformed body: expected error, got nil")
+	} else {
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) {
+			t.Fatalf("typed Execute() error = %T, want *APIError", err)
+		}
+		if len(apiErr.Body()) == 0 {
+			t.Fatal("typed Execute() *APIError carried no body")
+		}
+	}
+
+	body, resp, rawErr := c.GetBucketPresignedUrls(ctx).ExecuteRaw()
+	if rawErr != nil {
+		t.Fatalf("ExecuteRaw() on malformed body: unexpected error: %v", rawErr)
+	}
+	if resp == nil {
+		t.Fatal("ExecuteRaw() returned nil response")
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("ExecuteRaw() status = %d, want 200", resp.StatusCode)
+	}
+	if len(body) == 0 {
+		t.Fatal("ExecuteRaw() returned empty body")
+	}
+}

--- a/packages/python/tests/test_enum_tolerance.py
+++ b/packages/python/tests/test_enum_tolerance.py
@@ -1,0 +1,31 @@
+# Enum-typed wire fields are declared with a fixed set of values, but
+# the server may start sending a value the SDK does not know yet.
+# from_dict must accept the unknown string verbatim instead of
+# raising, and the typed constants must stay usable for comparisons.
+
+from yaylib.models.post import Post
+from yaylib.models.post_type import PostType
+
+
+def test_unknown_enum_value_is_kept_as_string():
+    post = Post.from_dict({"post_type": "__mock_unknown_enum__"})
+    assert post.post_type == "__mock_unknown_enum__"
+
+
+def test_known_enum_value_decodes_to_typed_constant():
+    post = Post.from_dict({"post_type": "image"})
+    assert post.post_type == PostType.IMAGE
+    # PostType is a str-backed Enum, so the typed constant compares
+    # equal to its wire string in both directions.
+    assert post.post_type == "image"
+    assert PostType.IMAGE == "image"
+    assert "image" == PostType.IMAGE
+
+
+def test_known_value_recognized_unknown_value_not():
+    # There is no dedicated IsValid()-style predicate on the enum in
+    # this port; the membership of a value among the enumerated
+    # constants is the equivalent introspection.
+    known = {member.value for member in PostType}
+    assert "image" in known
+    assert "__mock_unknown_enum__" not in known

--- a/packages/python/tests/test_execute_raw_parity.py
+++ b/packages/python/tests/test_execute_raw_parity.py
@@ -1,0 +1,51 @@
+# Raw-escape-hatch parity, driven against the shared behavior-contract
+# server's body-malformed contract (PORTING.md §15): the endpoint
+# answers HTTP 200 with a JSON scalar no typed model can decode. Two
+# halves:
+#
+#   1. the typed call surfaces the parse failure as an APIError that
+#      still carries the raw body (so code_of(err) / inspection works);
+#   2. the per-call raw escape hatch (client.execute_raw) hands back the
+#      unparsed bytes and the 200 HTTP response without raising.
+#
+# Skips when YAYLIB_MOCK_BASE_URL is unset, like every parity test.
+
+import pytest
+
+from yaylib.errors import APIError
+
+from ._parity import mock_client, require_mock
+
+
+async def test_typed_call_on_malformed_body_raises_apierror_with_raw_body():
+    require_mock()
+    c = mock_client("body-malformed")
+    try:
+        with pytest.raises(APIError) as excinfo:
+            await c.buckets_api.get_bucket_presigned_urls(file_names=["x"])
+        err = excinfo.value
+        # A 2xx body that does not match the typed model surfaces as an
+        # APIError that retains the raw body — not a bare validation
+        # error with nothing to inspect.
+        assert err.body, "typed parse error must retain the raw body"
+        assert len(str(err.body)) > 0
+    finally:
+        await c.close()
+
+
+async def test_execute_raw_returns_body_and_response_without_raising():
+    require_mock()
+    c = mock_client("body-malformed")
+    try:
+        body, resp = await c.execute_raw(
+            c.buckets_api.get_bucket_presigned_urls_without_preload_content(
+                file_names=["x"]
+            )
+        )
+        # The raw hatch bypasses the typed decode entirely: a 200 whose
+        # body the typed model rejects still comes back as bytes + the
+        # successful response, no error.
+        assert resp.status == 200
+        assert isinstance(body, (bytes, bytearray)) and len(body) > 0
+    finally:
+        await c.close()

--- a/packages/python/yaylib/_error_codes.py
+++ b/packages/python/yaylib/_error_codes.py
@@ -1,0 +1,391 @@
+# Code generated; DO NOT EDIT.
+#
+# ErrorCode mirrors the Yay! API error discriminator carried in the
+# JSON "error_code" field of a non-2xx response body. Use code_of(err)
+# to extract it and compare against these constants (PORTING.md §9).
+
+__all__ = [
+    "ErrCodeUnknown",
+    "ErrCodeInvalidParameter",
+    "ErrCodeRegisteredUser",
+    "ErrCodeAccessTokenExpired",
+    "ErrCodeScreenNameAlreadyBeenTaken",
+    "ErrCodeUserNotFound",
+    "ErrCodePostNotFound",
+    "ErrCodeChatRoomNotFound",
+    "ErrCodeChatMessageNotFound",
+    "ErrCodeUserNotFoundAtChatRoom",
+    "ErrCodeUserMustBeOverTwoAtChatRoom",
+    "ErrCodeIncorrectPassword",
+    "ErrCodeUserBlocked",
+    "ErrCodePrivateUser",
+    "ErrCodeApplicationNotFound",
+    "ErrCodeBadSNSCredentials",
+    "ErrCodeSNSAlreadyConnected",
+    "ErrCodeCannotDisconnectSNS",
+    "ErrCodeAccessTokenInvalid",
+    "ErrCodeSpotNotFound",
+    "ErrCodeUserBanned",
+    "ErrCodeUserTemporaryBanned",
+    "ErrCodeSchoolInfoChange",
+    "ErrCodeCannotDeleteNewUser",
+    "ErrCodeCaptchaRequired",
+    "ErrCodeFailedToVerifyCaptcha",
+    "ErrCodeRequired2FA",
+    "ErrCodeIncorrect2FA",
+    "ErrCodeGroupIsFull",
+    "ErrCodeBannedFromGroup",
+    "ErrCodeInvalidCurrentPassword",
+    "ErrCodeInvalidPassword",
+    "ErrCodeExistEmail",
+    "ErrCodeBadEmailReputation",
+    "ErrCodeChatRoomIsFull",
+    "ErrCodeConferenceIsFull",
+    "ErrCodeConferenceInactive",
+    "ErrCodeGroupOwnerBlockedYou",
+    "ErrCodeChatNeedMutualFollowed",
+    "ErrCodeConferenceCallIsLocked",
+    "ErrCodeConferenceCallIsForFollowersOnly",
+    "ErrCodeBannedFromCall",
+    "ErrCodeNotCallOwner",
+    "ErrCodeNotVipUser",
+    "ErrCodeBlockingLimitExceeded",
+    "ErrCodeVerificationCodeWrong",
+    "ErrCodeVerificationCodeExpired",
+    "ErrCodeFollowLimitation",
+    "ErrCodeAgeGapNotAllowed",
+    "ErrCodeGroupOwnerOrGroupModeratorOnly",
+    "ErrCodeSnsShareRewardAlreadyBeenClaimed",
+    "ErrCodeQuotaLimitExceeded",
+    "ErrCodeChatNeedAgeVerified",
+    "ErrCodeOnlyAgeVerifiedUserCanJoinGroup",
+    "ErrCodeRequirePhoneVerificationToChat",
+    "ErrCodeNotPostOwner",
+    "ErrCodeGroupGenerationNotMatched",
+    "ErrCodePhoneNumberCheckVerificationCodeSubmitQuotaExceeded",
+    "ErrCodePhoneNumberCheckVerificationCodeRequestQuotaExceeded",
+    "ErrCodeGroupOfferHasBeenAccepted",
+    "ErrCodeGroupOfferHasBeenWithdrawn",
+    "ErrCodeIpBanned",
+    "ErrCodeNotConnectedToTwitter",
+    "ErrCodePrivateUserTimeline",
+    "ErrCodeCounterRefreshLimitExceeded",
+    "ErrCodeNotFollowedByOpponent",
+    "ErrCodeExceedChangeCountryQuota",
+    "ErrCodeNotGroupMember",
+    "ErrCodeGroupPendingTransfer",
+    "ErrCodeGroupPendingDeputization",
+    "ErrCodeUserRestrictedChatWithCautionUsers",
+    "ErrCodeRestrictedCreateChatWithNewUsers",
+    "ErrCodeRepostPostNotRepostable",
+    "ErrCodeTooManyAccountsCreated",
+    "ErrCodeOnlySpecificGenderCanJoinGroup",
+    "ErrCodeCreateSpecificGenderGroupRequiredGender",
+    "ErrCodeGroupRelatedExceededNumberOfRelatedGroups",
+    "ErrCodeExceededPinnedLimit",
+    "ErrCodeGroupShareOnTwitterLimitExceeded",
+    "ErrCodeReportedContent",
+    "ErrCodeInsufficientCoins",
+    "ErrCodeConferenceCallIsForMutualFollowsOnly",
+    "ErrCodeExceededLimit",
+    "ErrCodeGroupInviteExceeded",
+    "ErrCodePhoneVerificationRequired",
+    "ErrCodeContentTooOld",
+    "ErrCodePasswordTooShort",
+    "ErrCodePasswordTooLong",
+    "ErrCodePasswordNotAllowed",
+    "ErrCodeCommonPassword",
+    "ErrCodeUnableToMovePostToThread",
+    "ErrCodeUnableToPostUrl",
+    "ErrCodeReferralAlreadyRegistered",
+    "ErrCodeMuteUserOverLimit",
+    "ErrCodeTextTranslationLimitExceeded",
+    "ErrCodeTextTranslation",
+    "ErrCodeCardExchangeLimit",
+    "ErrCodeInvalidAppVersion",
+    "ErrCodeDynamicErrorMessage",
+    "ErrCodePhoneNumberBanned",
+    "ErrCodeBadRequest",
+    "ErrCodeUnauthorized",
+    "ErrCodeAccessForbidden",
+    "ErrCodeNotFound",
+    "ErrCodeConflict",
+    "ErrCodeTooManyRequests",
+    "ErrCodeInternalServerError",
+    "ErrCodeWeb3AccountAlreadyLinkedToAnotherWallet",
+    "ErrCodeWeb3WalletAlreadyLinkedToAnotherAccount",
+    "ErrCodeWeb3AccountAlreadyLinkedToAnotherWallet2",
+    "ErrCodeWeb3PalLevelUpBattlesRequired",
+    "ErrCodeWeb3PalLevelUpMaximumLevelReached",
+    "ErrCodeWeb3PalPoolCooldown",
+    "ErrCodeWeb3PalPoolEmpty",
+    "ErrCodeWeb3PalAlreadyBattle",
+    "ErrCodeWeb3WalletHasPendingTransactions",
+    "ErrCodeWeb3WalletNetworkError",
+    "ErrCodeWeb3EMPLInsufficientFunds",
+    "ErrCodeWeb3EMPLFeeExceedsBalance",
+    "ErrCodeWeb3EMPLAmountInsufficientToCoverGasFee",
+    "ErrCodeWeb3EMPLInsufficientNativeBalance",
+    "ErrCodeWeb3EMPLExchangeExceedsRemainingQuota",
+    "ErrCodeOffline",
+    "ErrCodeCallOpponentDisabled",
+    "error_code_name",
+]
+
+ErrCodeUnknown: int = 0
+ErrCodeInvalidParameter: int = -1
+ErrCodeRegisteredUser: int = -2
+ErrCodeAccessTokenExpired: int = -3
+ErrCodeScreenNameAlreadyBeenTaken: int = -4
+ErrCodeUserNotFound: int = -5
+ErrCodePostNotFound: int = -6
+ErrCodeChatRoomNotFound: int = -7
+ErrCodeChatMessageNotFound: int = -8
+ErrCodeUserNotFoundAtChatRoom: int = -9
+ErrCodeUserMustBeOverTwoAtChatRoom: int = -10
+ErrCodeIncorrectPassword: int = -11
+ErrCodeUserBlocked: int = -12
+ErrCodePrivateUser: int = -13
+ErrCodeApplicationNotFound: int = -14
+ErrCodeBadSNSCredentials: int = -15
+ErrCodeSNSAlreadyConnected: int = -16
+ErrCodeCannotDisconnectSNS: int = -17
+ErrCodeAccessTokenInvalid: int = -18
+ErrCodeSpotNotFound: int = -19
+ErrCodeUserBanned: int = -20
+ErrCodeUserTemporaryBanned: int = -21
+ErrCodeSchoolInfoChange: int = -22
+ErrCodeCannotDeleteNewUser: int = -26
+ErrCodeCaptchaRequired: int = -29
+ErrCodeFailedToVerifyCaptcha: int = -30
+ErrCodeRequired2FA: int = -31
+ErrCodeIncorrect2FA: int = -32
+ErrCodeGroupIsFull: int = -100
+ErrCodeBannedFromGroup: int = -103
+ErrCodeInvalidCurrentPassword: int = -201
+ErrCodeInvalidPassword: int = -202
+ErrCodeExistEmail: int = -203
+ErrCodeBadEmailReputation: int = -204
+ErrCodeChatRoomIsFull: int = -308
+ErrCodeConferenceIsFull: int = -309
+ErrCodeConferenceInactive: int = -310
+ErrCodeGroupOwnerBlockedYou: int = -312
+ErrCodeChatNeedMutualFollowed: int = -313
+ErrCodeConferenceCallIsLocked: int = -315
+ErrCodeConferenceCallIsForFollowersOnly: int = -317
+ErrCodeBannedFromCall: int = -321
+ErrCodeNotCallOwner: int = -322
+ErrCodeNotVipUser: int = -326
+ErrCodeBlockingLimitExceeded: int = -331
+ErrCodeVerificationCodeWrong: int = -332
+ErrCodeVerificationCodeExpired: int = -333
+ErrCodeFollowLimitation: int = -336
+ErrCodeAgeGapNotAllowed: int = -338
+ErrCodeGroupOwnerOrGroupModeratorOnly: int = -339
+ErrCodeSnsShareRewardAlreadyBeenClaimed: int = -342
+ErrCodeQuotaLimitExceeded: int = -343
+ErrCodeChatNeedAgeVerified: int = -346
+ErrCodeOnlyAgeVerifiedUserCanJoinGroup: int = -347
+ErrCodeRequirePhoneVerificationToChat: int = -348
+ErrCodeNotPostOwner: int = -350
+ErrCodeGroupGenerationNotMatched: int = -352
+ErrCodePhoneNumberCheckVerificationCodeSubmitQuotaExceeded: int = -355
+ErrCodePhoneNumberCheckVerificationCodeRequestQuotaExceeded: int = -356
+ErrCodeGroupOfferHasBeenAccepted: int = -357
+ErrCodeGroupOfferHasBeenWithdrawn: int = -358
+ErrCodeIpBanned: int = -360
+ErrCodeNotConnectedToTwitter: int = -361
+ErrCodePrivateUserTimeline: int = -363
+ErrCodeCounterRefreshLimitExceeded: int = -364
+ErrCodeNotFollowedByOpponent: int = -367
+ErrCodeExceedChangeCountryQuota: int = -369
+ErrCodeNotGroupMember: int = -370
+ErrCodeGroupPendingTransfer: int = -371
+ErrCodeGroupPendingDeputization: int = -372
+ErrCodeUserRestrictedChatWithCautionUsers: int = -373
+ErrCodeRestrictedCreateChatWithNewUsers: int = -374
+ErrCodeRepostPostNotRepostable: int = -375
+ErrCodeTooManyAccountsCreated: int = -376
+ErrCodeOnlySpecificGenderCanJoinGroup: int = -377
+ErrCodeCreateSpecificGenderGroupRequiredGender: int = -378
+ErrCodeGroupRelatedExceededNumberOfRelatedGroups: int = -382
+ErrCodeExceededPinnedLimit: int = -383
+ErrCodeGroupShareOnTwitterLimitExceeded: int = -384
+ErrCodeReportedContent: int = -385
+ErrCodeInsufficientCoins: int = -400
+ErrCodeConferenceCallIsForMutualFollowsOnly: int = -402
+ErrCodeExceededLimit: int = -403
+ErrCodeGroupInviteExceeded: int = -404
+ErrCodePhoneVerificationRequired: int = -405
+ErrCodeContentTooOld: int = -406
+ErrCodePasswordTooShort: int = -407
+ErrCodePasswordTooLong: int = -408
+ErrCodePasswordNotAllowed: int = -409
+ErrCodeCommonPassword: int = -410
+ErrCodeUnableToMovePostToThread: int = -412
+ErrCodeUnableToPostUrl: int = -413
+ErrCodeReferralAlreadyRegistered: int = -415
+ErrCodeMuteUserOverLimit: int = -416
+ErrCodeTextTranslationLimitExceeded: int = -419
+ErrCodeTextTranslation: int = -420
+ErrCodeCardExchangeLimit: int = -424
+ErrCodeInvalidAppVersion: int = -800
+ErrCodeDynamicErrorMessage: int = -999
+ErrCodePhoneNumberBanned: int = -1000
+ErrCodeBadRequest: int = 400
+ErrCodeUnauthorized: int = 401
+ErrCodeAccessForbidden: int = 403
+ErrCodeNotFound: int = 404
+ErrCodeConflict: int = 409
+ErrCodeTooManyRequests: int = 429
+ErrCodeInternalServerError: int = 500
+ErrCodeWeb3AccountAlreadyLinkedToAnotherWallet: int = 4002
+ErrCodeWeb3WalletAlreadyLinkedToAnotherAccount: int = 4003
+ErrCodeWeb3AccountAlreadyLinkedToAnotherWallet2: int = 4004
+ErrCodeWeb3PalLevelUpBattlesRequired: int = 4005
+ErrCodeWeb3PalLevelUpMaximumLevelReached: int = 4006
+ErrCodeWeb3PalPoolCooldown: int = 4010
+ErrCodeWeb3PalPoolEmpty: int = 4011
+ErrCodeWeb3PalAlreadyBattle: int = 4012
+ErrCodeWeb3WalletHasPendingTransactions: int = 4017
+ErrCodeWeb3WalletNetworkError: int = 5003
+ErrCodeWeb3EMPLInsufficientFunds: int = 6001
+ErrCodeWeb3EMPLFeeExceedsBalance: int = 6002
+ErrCodeWeb3EMPLAmountInsufficientToCoverGasFee: int = 6004
+ErrCodeWeb3EMPLInsufficientNativeBalance: int = 6007
+ErrCodeWeb3EMPLExchangeExceedsRemainingQuota: int = 6008
+ErrCodeOffline: int = 10000
+ErrCodeCallOpponentDisabled: int = 10001
+
+_NAMES = {
+    0: "Unknown",
+    -1: "InvalidParameter",
+    -2: "RegisteredUser",
+    -3: "AccessTokenExpired",
+    -4: "ScreenNameAlreadyBeenTaken",
+    -5: "UserNotFound",
+    -6: "PostNotFound",
+    -7: "ChatRoomNotFound",
+    -8: "ChatMessageNotFound",
+    -9: "UserNotFoundAtChatRoom",
+    -10: "UserMustBeOverTwoAtChatRoom",
+    -11: "IncorrectPassword",
+    -12: "UserBlocked",
+    -13: "PrivateUser",
+    -14: "ApplicationNotFound",
+    -15: "BadSNSCredentials",
+    -16: "SNSAlreadyConnected",
+    -17: "CannotDisconnectSNS",
+    -18: "AccessTokenInvalid",
+    -19: "SpotNotFound",
+    -20: "UserBanned",
+    -21: "UserTemporaryBanned",
+    -22: "SchoolInfoChange",
+    -26: "CannotDeleteNewUser",
+    -29: "CaptchaRequired",
+    -30: "FailedToVerifyCaptcha",
+    -31: "Required2FA",
+    -32: "Incorrect2FA",
+    -100: "GroupIsFull",
+    -103: "BannedFromGroup",
+    -201: "InvalidCurrentPassword",
+    -202: "InvalidPassword",
+    -203: "ExistEmail",
+    -204: "BadEmailReputation",
+    -308: "ChatRoomIsFull",
+    -309: "ConferenceIsFull",
+    -310: "ConferenceInactive",
+    -312: "GroupOwnerBlockedYou",
+    -313: "ChatNeedMutualFollowed",
+    -315: "ConferenceCallIsLocked",
+    -317: "ConferenceCallIsForFollowersOnly",
+    -321: "BannedFromCall",
+    -322: "NotCallOwner",
+    -326: "NotVipUser",
+    -331: "BlockingLimitExceeded",
+    -332: "VerificationCodeWrong",
+    -333: "VerificationCodeExpired",
+    -336: "FollowLimitation",
+    -338: "AgeGapNotAllowed",
+    -339: "GroupOwnerOrGroupModeratorOnly",
+    -342: "SnsShareRewardAlreadyBeenClaimed",
+    -343: "QuotaLimitExceeded",
+    -346: "ChatNeedAgeVerified",
+    -347: "OnlyAgeVerifiedUserCanJoinGroup",
+    -348: "RequirePhoneVerificationToChat",
+    -350: "NotPostOwner",
+    -352: "GroupGenerationNotMatched",
+    -355: "PhoneNumberCheckVerificationCodeSubmitQuotaExceeded",
+    -356: "PhoneNumberCheckVerificationCodeRequestQuotaExceeded",
+    -357: "GroupOfferHasBeenAccepted",
+    -358: "GroupOfferHasBeenWithdrawn",
+    -360: "IpBanned",
+    -361: "NotConnectedToTwitter",
+    -363: "PrivateUserTimeline",
+    -364: "CounterRefreshLimitExceeded",
+    -367: "NotFollowedByOpponent",
+    -369: "ExceedChangeCountryQuota",
+    -370: "NotGroupMember",
+    -371: "GroupPendingTransfer",
+    -372: "GroupPendingDeputization",
+    -373: "UserRestrictedChatWithCautionUsers",
+    -374: "RestrictedCreateChatWithNewUsers",
+    -375: "RepostPostNotRepostable",
+    -376: "TooManyAccountsCreated",
+    -377: "OnlySpecificGenderCanJoinGroup",
+    -378: "CreateSpecificGenderGroupRequiredGender",
+    -382: "GroupRelatedExceededNumberOfRelatedGroups",
+    -383: "ExceededPinnedLimit",
+    -384: "GroupShareOnTwitterLimitExceeded",
+    -385: "ReportedContent",
+    -400: "InsufficientCoins",
+    -402: "ConferenceCallIsForMutualFollowsOnly",
+    -403: "ExceededLimit",
+    -404: "GroupInviteExceeded",
+    -405: "PhoneVerificationRequired",
+    -406: "ContentTooOld",
+    -407: "PasswordTooShort",
+    -408: "PasswordTooLong",
+    -409: "PasswordNotAllowed",
+    -410: "CommonPassword",
+    -412: "UnableToMovePostToThread",
+    -413: "UnableToPostUrl",
+    -415: "ReferralAlreadyRegistered",
+    -416: "MuteUserOverLimit",
+    -419: "TextTranslationLimitExceeded",
+    -420: "TextTranslation",
+    -424: "CardExchangeLimit",
+    -800: "InvalidAppVersion",
+    -999: "DynamicErrorMessage",
+    -1000: "PhoneNumberBanned",
+    400: "BadRequest",
+    401: "Unauthorized",
+    403: "AccessForbidden",
+    404: "NotFound",
+    409: "Conflict",
+    429: "TooManyRequests",
+    500: "InternalServerError",
+    4002: "Web3AccountAlreadyLinkedToAnotherWallet",
+    4003: "Web3WalletAlreadyLinkedToAnotherAccount",
+    4004: "Web3AccountAlreadyLinkedToAnotherWallet2",
+    4005: "Web3PalLevelUpBattlesRequired",
+    4006: "Web3PalLevelUpMaximumLevelReached",
+    4010: "Web3PalPoolCooldown",
+    4011: "Web3PalPoolEmpty",
+    4012: "Web3PalAlreadyBattle",
+    4017: "Web3WalletHasPendingTransactions",
+    5003: "Web3WalletNetworkError",
+    6001: "Web3EMPLInsufficientFunds",
+    6002: "Web3EMPLFeeExceedsBalance",
+    6004: "Web3EMPLAmountInsufficientToCoverGasFee",
+    6007: "Web3EMPLInsufficientNativeBalance",
+    6008: "Web3EMPLExchangeExceedsRemainingQuota",
+    10000: "Offline",
+    10001: "CallOpponentDisabled",
+}
+
+
+def error_code_name(c: int) -> str:
+    """Canonical name (e.g. \"UserNotFound\"); an unrecognized code
+    renders as \"ErrorCode(<n>)\"."""
+    return _NAMES.get(c, f"ErrorCode({c})")

--- a/packages/python/yaylib/api_client.py
+++ b/packages/python/yaylib/api_client.py
@@ -336,7 +336,21 @@ class ApiClient:
                     match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
                 encoding = match.group(1) if match else "utf-8"
                 response_text = response_data.data.decode(encoding)
-                return_data = self.deserialize(response_text, response_type, content_type)
+                try:
+                    return_data = self.deserialize(response_text, response_type, content_type)
+                except Exception:
+                    # A 2xx body that does not match the typed model
+                    # must surface as an APIError carrying the raw body
+                    # (so the caller can inspect it or use the raw
+                    # escape hatch), the same as the other language
+                    # clients -- not a bare validation error with no body.
+                    if 200 <= response_data.status <= 299:
+                        raise ApiException.from_response(
+                            http_resp=response_data,
+                            body=response_text,
+                            data=None,
+                        )
+                    raise
         finally:
             if not 200 <= response_data.status <= 299:
                 raise ApiException.from_response(

--- a/packages/python/yaylib/client.py
+++ b/packages/python/yaylib/client.py
@@ -43,6 +43,7 @@ from yaylib.api.threads_api import ThreadsApi
 from yaylib.api.users_api import UsersApi
 from yaylib.api_client import ApiClient
 from yaylib.configuration import Configuration
+from yaylib.exceptions import ApiException
 
 from yaylib._config import (
     DEFAULT_ACCEPT_LANGUAGE,
@@ -290,6 +291,43 @@ class Client:
                 pass
         self._bg_tasks.clear()
         await self._transport.close()
+
+    # ---- raw escape hatch (PORTING.md §11.3) ----
+
+    async def execute_raw(self, raw_call):
+        """Run a generated ``*_without_preload_content`` operation and
+        return ``(body: bytes, response)`` with the typed JSON decode
+        bypassed entirely (PORTING.md §11.3 / §15). A typed-decode
+        failure can never occur here — the bytes are read straight off
+        the response. An HTTP error still surfaces as an ``APIError``
+        carrying the raw body (so ``code_of(err)`` keeps working); a
+        transport failure surfaces as an ``APIError`` too.
+
+        Python's generated client is method-based (no request builder),
+        so the sibling raw call is passed in explicitly::
+
+            body, resp = await client.execute_raw(
+                client.buckets_api.get_bucket_presigned_urls_without_preload_content(
+                    file_names=["x"]
+                )
+            )
+        """
+        from yaylib.errors import as_api_error
+
+        try:
+            resp = await raw_call
+            body = await resp.read()
+        except ApiException:
+            raise
+        except Exception as err:  # noqa: BLE001 — transport failure
+            raise as_api_error(err)
+        if not 200 <= resp.status <= 299:
+            raise ApiException.from_response(
+                http_resp=resp,
+                body=body.decode("utf-8", "replace"),
+                data=None,
+            )
+        return body, resp
 
     # ---- uploads (PORTING.md §8) ----
 

--- a/packages/python/yaylib/errors.py
+++ b/packages/python/yaylib/errors.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 from yaylib.exceptions import ApiException as APIError
+from yaylib import _error_codes
+from yaylib._error_codes import *  # noqa: F401,F403 — generated ErrCode* constants
 
 __all__ = [
     "APIError",
@@ -23,7 +25,7 @@ __all__ = [
     "error_response_of",
     "code_of",
     "as_api_error",
-]
+] + list(_error_codes.__all__)
 
 
 @dataclass

--- a/packages/python/yaylib/transport.py
+++ b/packages/python/yaylib/transport.py
@@ -134,6 +134,15 @@ class BufferedResponse:
     async def read(self) -> bytes:
         return self.data
 
+    @property
+    def response(self):
+        # The generated ``*_without_preload_content`` raw sibling returns
+        # ``response_data.response``. This wrapper already *is* the
+        # buffered, RESTResponse-compatible object (``read`` / ``status``
+        # / ``getheaders``), so hand back self instead of an unbuffered
+        # connection object the buffered transport never keeps.
+        return self
+
     def getheaders(self) -> "CIMultiDict[str]":
         return self._headers
 

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
     "typecheck": "tsc --noEmit",
-    "test": "tsx tests/signing.test.ts && tsx tests/auth_refresh.test.ts && tsx tests/session_file.test.ts && tsx tests/auth.test.ts && tsx tests/retry.test.ts && tsx tests/upload.test.ts && tsx tests/event_stream.test.ts && tsx tests/execute_raw.test.ts && tsx tests/cursor_tolerance.test.ts && tsx tests/realm_list.test.ts && tsx tests/host_routes.test.ts && tsx tests/logging.test.ts && tsx tests/retry_parity.test.ts && tsx tests/transport_parity.test.ts && tsx tests/logging_parity.test.ts && tsx tests/event_stream_parity.test.ts && tsx tests/upload_parity.test.ts",
+    "test": "tsx tests/signing.test.ts && tsx tests/auth_refresh.test.ts && tsx tests/session_file.test.ts && tsx tests/auth.test.ts && tsx tests/retry.test.ts && tsx tests/upload.test.ts && tsx tests/event_stream.test.ts && tsx tests/execute_raw.test.ts && tsx tests/cursor_tolerance.test.ts && tsx tests/realm_list.test.ts && tsx tests/host_routes.test.ts && tsx tests/logging.test.ts && tsx tests/transport.test.ts && tsx tests/auth_extra.test.ts && tsx tests/enum_tolerance.test.ts && tsx tests/retry_parity.test.ts && tsx tests/transport_parity.test.ts && tsx tests/logging_parity.test.ts && tsx tests/event_stream_parity.test.ts && tsx tests/upload_parity.test.ts",
     "prepare": "npm run build"
   },
   "engines": {

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -88,6 +88,7 @@ import type { Tokens } from "./tokens";
 import { emptyTokens } from "./tokens";
 import {
   buildAuthRefreshMiddleware,
+  buildClientIPMiddleware,
   buildHeadersMiddleware,
   buildHostRoutingMiddleware,
 } from "./transport";
@@ -162,6 +163,7 @@ export class Client {
   private _userID = 0;
   private _currentEmail = "";
   private _clientIP = "";
+  private _clientIPFetching = false;
   // Single-flight refresh tracking — concurrent 401s collapse onto one
   // OAuth /token round-trip (PORTING.md §6.1).
   private _refreshInFlight: Promise<boolean> | null = null;
@@ -265,6 +267,12 @@ export class Client {
           policy: this.retryPolicy,
           logger: this.logger,
           fetchApi: opts.fetchApi,
+        }),
+        // Observes responses to lazily learn the caller's outbound IP
+        // for the X-Client-IP header. Post-only, so its placement after
+        // retry is irrelevant to the request shape.
+        buildClientIPMiddleware({
+          maybeFetchClientIP: () => this._maybeFetchClientIP(),
         }),
       ],
     });
@@ -537,6 +545,29 @@ export class Client {
       // Transport failure (FetchError or anything non-HTTP).
       return { error: await asAPIError(err) };
     }
+  }
+
+  // Internal — invoked by the client-IP middleware (transport.ts) after
+  // the first non-lookup response. Best-effort: a single background
+  // lookup of the caller's outbound IP via getUserTimestamp, cached into
+  // _clientIP so later requests carry X-Client-IP. A lookup already in
+  // flight, or an IP already known, makes this a no-op; a failed lookup
+  // leaves the value empty so a later request retries.
+  private _maybeFetchClientIP(): void {
+    if (this._clientIP !== "" || this._clientIPFetching) return;
+    this._clientIPFetching = true;
+    void (async () => {
+      let ip = "";
+      try {
+        const resp = await this.usersAPI.getUserTimestamp();
+        ip = resp.ipAddress ?? "";
+      } catch {
+        /* leave empty; a later request retries */
+      } finally {
+        this._clientIPFetching = false;
+        if (ip !== "") this._clientIP = ip;
+      }
+    })();
   }
 
   /** Internal — invoked by the auth-refresh middleware (transport.ts). */

--- a/packages/typescript/src/error_codes.ts
+++ b/packages/typescript/src/error_codes.ts
@@ -1,0 +1,266 @@
+// Code generated; DO NOT EDIT.
+//
+// ErrorCode mirrors the Yay! API error discriminator carried in the
+// JSON "error_code" field of a non-2xx response body. Use codeOf(err)
+// to extract it and compare against these constants for switch /
+// dispatch (PORTING.md §9).
+
+export type ErrorCode = number;
+
+export const ErrCodeUnknown: ErrorCode = 0;
+export const ErrCodeInvalidParameter: ErrorCode = -1;
+export const ErrCodeRegisteredUser: ErrorCode = -2;
+export const ErrCodeAccessTokenExpired: ErrorCode = -3;
+export const ErrCodeScreenNameAlreadyBeenTaken: ErrorCode = -4;
+export const ErrCodeUserNotFound: ErrorCode = -5;
+export const ErrCodePostNotFound: ErrorCode = -6;
+export const ErrCodeChatRoomNotFound: ErrorCode = -7;
+export const ErrCodeChatMessageNotFound: ErrorCode = -8;
+export const ErrCodeUserNotFoundAtChatRoom: ErrorCode = -9;
+export const ErrCodeUserMustBeOverTwoAtChatRoom: ErrorCode = -10;
+export const ErrCodeIncorrectPassword: ErrorCode = -11;
+export const ErrCodeUserBlocked: ErrorCode = -12;
+export const ErrCodePrivateUser: ErrorCode = -13;
+export const ErrCodeApplicationNotFound: ErrorCode = -14;
+export const ErrCodeBadSNSCredentials: ErrorCode = -15;
+export const ErrCodeSNSAlreadyConnected: ErrorCode = -16;
+export const ErrCodeCannotDisconnectSNS: ErrorCode = -17;
+export const ErrCodeAccessTokenInvalid: ErrorCode = -18;
+export const ErrCodeSpotNotFound: ErrorCode = -19;
+export const ErrCodeUserBanned: ErrorCode = -20;
+export const ErrCodeUserTemporaryBanned: ErrorCode = -21;
+export const ErrCodeSchoolInfoChange: ErrorCode = -22;
+export const ErrCodeCannotDeleteNewUser: ErrorCode = -26;
+export const ErrCodeCaptchaRequired: ErrorCode = -29;
+export const ErrCodeFailedToVerifyCaptcha: ErrorCode = -30;
+export const ErrCodeRequired2FA: ErrorCode = -31;
+export const ErrCodeIncorrect2FA: ErrorCode = -32;
+export const ErrCodeGroupIsFull: ErrorCode = -100;
+export const ErrCodeBannedFromGroup: ErrorCode = -103;
+export const ErrCodeInvalidCurrentPassword: ErrorCode = -201;
+export const ErrCodeInvalidPassword: ErrorCode = -202;
+export const ErrCodeExistEmail: ErrorCode = -203;
+export const ErrCodeBadEmailReputation: ErrorCode = -204;
+export const ErrCodeChatRoomIsFull: ErrorCode = -308;
+export const ErrCodeConferenceIsFull: ErrorCode = -309;
+export const ErrCodeConferenceInactive: ErrorCode = -310;
+export const ErrCodeGroupOwnerBlockedYou: ErrorCode = -312;
+export const ErrCodeChatNeedMutualFollowed: ErrorCode = -313;
+export const ErrCodeConferenceCallIsLocked: ErrorCode = -315;
+export const ErrCodeConferenceCallIsForFollowersOnly: ErrorCode = -317;
+export const ErrCodeBannedFromCall: ErrorCode = -321;
+export const ErrCodeNotCallOwner: ErrorCode = -322;
+export const ErrCodeNotVipUser: ErrorCode = -326;
+export const ErrCodeBlockingLimitExceeded: ErrorCode = -331;
+export const ErrCodeVerificationCodeWrong: ErrorCode = -332;
+export const ErrCodeVerificationCodeExpired: ErrorCode = -333;
+export const ErrCodeFollowLimitation: ErrorCode = -336;
+export const ErrCodeAgeGapNotAllowed: ErrorCode = -338;
+export const ErrCodeGroupOwnerOrGroupModeratorOnly: ErrorCode = -339;
+export const ErrCodeSnsShareRewardAlreadyBeenClaimed: ErrorCode = -342;
+export const ErrCodeQuotaLimitExceeded: ErrorCode = -343;
+export const ErrCodeChatNeedAgeVerified: ErrorCode = -346;
+export const ErrCodeOnlyAgeVerifiedUserCanJoinGroup: ErrorCode = -347;
+export const ErrCodeRequirePhoneVerificationToChat: ErrorCode = -348;
+export const ErrCodeNotPostOwner: ErrorCode = -350;
+export const ErrCodeGroupGenerationNotMatched: ErrorCode = -352;
+export const ErrCodePhoneNumberCheckVerificationCodeSubmitQuotaExceeded: ErrorCode = -355;
+export const ErrCodePhoneNumberCheckVerificationCodeRequestQuotaExceeded: ErrorCode = -356;
+export const ErrCodeGroupOfferHasBeenAccepted: ErrorCode = -357;
+export const ErrCodeGroupOfferHasBeenWithdrawn: ErrorCode = -358;
+export const ErrCodeIpBanned: ErrorCode = -360;
+export const ErrCodeNotConnectedToTwitter: ErrorCode = -361;
+export const ErrCodePrivateUserTimeline: ErrorCode = -363;
+export const ErrCodeCounterRefreshLimitExceeded: ErrorCode = -364;
+export const ErrCodeNotFollowedByOpponent: ErrorCode = -367;
+export const ErrCodeExceedChangeCountryQuota: ErrorCode = -369;
+export const ErrCodeNotGroupMember: ErrorCode = -370;
+export const ErrCodeGroupPendingTransfer: ErrorCode = -371;
+export const ErrCodeGroupPendingDeputization: ErrorCode = -372;
+export const ErrCodeUserRestrictedChatWithCautionUsers: ErrorCode = -373;
+export const ErrCodeRestrictedCreateChatWithNewUsers: ErrorCode = -374;
+export const ErrCodeRepostPostNotRepostable: ErrorCode = -375;
+export const ErrCodeTooManyAccountsCreated: ErrorCode = -376;
+export const ErrCodeOnlySpecificGenderCanJoinGroup: ErrorCode = -377;
+export const ErrCodeCreateSpecificGenderGroupRequiredGender: ErrorCode = -378;
+export const ErrCodeGroupRelatedExceededNumberOfRelatedGroups: ErrorCode = -382;
+export const ErrCodeExceededPinnedLimit: ErrorCode = -383;
+export const ErrCodeGroupShareOnTwitterLimitExceeded: ErrorCode = -384;
+export const ErrCodeReportedContent: ErrorCode = -385;
+export const ErrCodeInsufficientCoins: ErrorCode = -400;
+export const ErrCodeConferenceCallIsForMutualFollowsOnly: ErrorCode = -402;
+export const ErrCodeExceededLimit: ErrorCode = -403;
+export const ErrCodeGroupInviteExceeded: ErrorCode = -404;
+export const ErrCodePhoneVerificationRequired: ErrorCode = -405;
+export const ErrCodeContentTooOld: ErrorCode = -406;
+export const ErrCodePasswordTooShort: ErrorCode = -407;
+export const ErrCodePasswordTooLong: ErrorCode = -408;
+export const ErrCodePasswordNotAllowed: ErrorCode = -409;
+export const ErrCodeCommonPassword: ErrorCode = -410;
+export const ErrCodeUnableToMovePostToThread: ErrorCode = -412;
+export const ErrCodeUnableToPostUrl: ErrorCode = -413;
+export const ErrCodeReferralAlreadyRegistered: ErrorCode = -415;
+export const ErrCodeMuteUserOverLimit: ErrorCode = -416;
+export const ErrCodeTextTranslationLimitExceeded: ErrorCode = -419;
+export const ErrCodeTextTranslation: ErrorCode = -420;
+export const ErrCodeCardExchangeLimit: ErrorCode = -424;
+export const ErrCodeInvalidAppVersion: ErrorCode = -800;
+export const ErrCodeDynamicErrorMessage: ErrorCode = -999;
+export const ErrCodePhoneNumberBanned: ErrorCode = -1000;
+export const ErrCodeBadRequest: ErrorCode = 400;
+export const ErrCodeUnauthorized: ErrorCode = 401;
+export const ErrCodeAccessForbidden: ErrorCode = 403;
+export const ErrCodeNotFound: ErrorCode = 404;
+export const ErrCodeConflict: ErrorCode = 409;
+export const ErrCodeTooManyRequests: ErrorCode = 429;
+export const ErrCodeInternalServerError: ErrorCode = 500;
+export const ErrCodeWeb3AccountAlreadyLinkedToAnotherWallet: ErrorCode = 4002;
+export const ErrCodeWeb3WalletAlreadyLinkedToAnotherAccount: ErrorCode = 4003;
+export const ErrCodeWeb3AccountAlreadyLinkedToAnotherWallet2: ErrorCode = 4004;
+export const ErrCodeWeb3PalLevelUpBattlesRequired: ErrorCode = 4005;
+export const ErrCodeWeb3PalLevelUpMaximumLevelReached: ErrorCode = 4006;
+export const ErrCodeWeb3PalPoolCooldown: ErrorCode = 4010;
+export const ErrCodeWeb3PalPoolEmpty: ErrorCode = 4011;
+export const ErrCodeWeb3PalAlreadyBattle: ErrorCode = 4012;
+export const ErrCodeWeb3WalletHasPendingTransactions: ErrorCode = 4017;
+export const ErrCodeWeb3WalletNetworkError: ErrorCode = 5003;
+export const ErrCodeWeb3EMPLInsufficientFunds: ErrorCode = 6001;
+export const ErrCodeWeb3EMPLFeeExceedsBalance: ErrorCode = 6002;
+export const ErrCodeWeb3EMPLAmountInsufficientToCoverGasFee: ErrorCode = 6004;
+export const ErrCodeWeb3EMPLInsufficientNativeBalance: ErrorCode = 6007;
+export const ErrCodeWeb3EMPLExchangeExceedsRemainingQuota: ErrorCode = 6008;
+export const ErrCodeOffline: ErrorCode = 10000;
+export const ErrCodeCallOpponentDisabled: ErrorCode = 10001;
+
+const NAMES: Record<number, string> = {
+  [0]: "Unknown",
+  [-1]: "InvalidParameter",
+  [-2]: "RegisteredUser",
+  [-3]: "AccessTokenExpired",
+  [-4]: "ScreenNameAlreadyBeenTaken",
+  [-5]: "UserNotFound",
+  [-6]: "PostNotFound",
+  [-7]: "ChatRoomNotFound",
+  [-8]: "ChatMessageNotFound",
+  [-9]: "UserNotFoundAtChatRoom",
+  [-10]: "UserMustBeOverTwoAtChatRoom",
+  [-11]: "IncorrectPassword",
+  [-12]: "UserBlocked",
+  [-13]: "PrivateUser",
+  [-14]: "ApplicationNotFound",
+  [-15]: "BadSNSCredentials",
+  [-16]: "SNSAlreadyConnected",
+  [-17]: "CannotDisconnectSNS",
+  [-18]: "AccessTokenInvalid",
+  [-19]: "SpotNotFound",
+  [-20]: "UserBanned",
+  [-21]: "UserTemporaryBanned",
+  [-22]: "SchoolInfoChange",
+  [-26]: "CannotDeleteNewUser",
+  [-29]: "CaptchaRequired",
+  [-30]: "FailedToVerifyCaptcha",
+  [-31]: "Required2FA",
+  [-32]: "Incorrect2FA",
+  [-100]: "GroupIsFull",
+  [-103]: "BannedFromGroup",
+  [-201]: "InvalidCurrentPassword",
+  [-202]: "InvalidPassword",
+  [-203]: "ExistEmail",
+  [-204]: "BadEmailReputation",
+  [-308]: "ChatRoomIsFull",
+  [-309]: "ConferenceIsFull",
+  [-310]: "ConferenceInactive",
+  [-312]: "GroupOwnerBlockedYou",
+  [-313]: "ChatNeedMutualFollowed",
+  [-315]: "ConferenceCallIsLocked",
+  [-317]: "ConferenceCallIsForFollowersOnly",
+  [-321]: "BannedFromCall",
+  [-322]: "NotCallOwner",
+  [-326]: "NotVipUser",
+  [-331]: "BlockingLimitExceeded",
+  [-332]: "VerificationCodeWrong",
+  [-333]: "VerificationCodeExpired",
+  [-336]: "FollowLimitation",
+  [-338]: "AgeGapNotAllowed",
+  [-339]: "GroupOwnerOrGroupModeratorOnly",
+  [-342]: "SnsShareRewardAlreadyBeenClaimed",
+  [-343]: "QuotaLimitExceeded",
+  [-346]: "ChatNeedAgeVerified",
+  [-347]: "OnlyAgeVerifiedUserCanJoinGroup",
+  [-348]: "RequirePhoneVerificationToChat",
+  [-350]: "NotPostOwner",
+  [-352]: "GroupGenerationNotMatched",
+  [-355]: "PhoneNumberCheckVerificationCodeSubmitQuotaExceeded",
+  [-356]: "PhoneNumberCheckVerificationCodeRequestQuotaExceeded",
+  [-357]: "GroupOfferHasBeenAccepted",
+  [-358]: "GroupOfferHasBeenWithdrawn",
+  [-360]: "IpBanned",
+  [-361]: "NotConnectedToTwitter",
+  [-363]: "PrivateUserTimeline",
+  [-364]: "CounterRefreshLimitExceeded",
+  [-367]: "NotFollowedByOpponent",
+  [-369]: "ExceedChangeCountryQuota",
+  [-370]: "NotGroupMember",
+  [-371]: "GroupPendingTransfer",
+  [-372]: "GroupPendingDeputization",
+  [-373]: "UserRestrictedChatWithCautionUsers",
+  [-374]: "RestrictedCreateChatWithNewUsers",
+  [-375]: "RepostPostNotRepostable",
+  [-376]: "TooManyAccountsCreated",
+  [-377]: "OnlySpecificGenderCanJoinGroup",
+  [-378]: "CreateSpecificGenderGroupRequiredGender",
+  [-382]: "GroupRelatedExceededNumberOfRelatedGroups",
+  [-383]: "ExceededPinnedLimit",
+  [-384]: "GroupShareOnTwitterLimitExceeded",
+  [-385]: "ReportedContent",
+  [-400]: "InsufficientCoins",
+  [-402]: "ConferenceCallIsForMutualFollowsOnly",
+  [-403]: "ExceededLimit",
+  [-404]: "GroupInviteExceeded",
+  [-405]: "PhoneVerificationRequired",
+  [-406]: "ContentTooOld",
+  [-407]: "PasswordTooShort",
+  [-408]: "PasswordTooLong",
+  [-409]: "PasswordNotAllowed",
+  [-410]: "CommonPassword",
+  [-412]: "UnableToMovePostToThread",
+  [-413]: "UnableToPostUrl",
+  [-415]: "ReferralAlreadyRegistered",
+  [-416]: "MuteUserOverLimit",
+  [-419]: "TextTranslationLimitExceeded",
+  [-420]: "TextTranslation",
+  [-424]: "CardExchangeLimit",
+  [-800]: "InvalidAppVersion",
+  [-999]: "DynamicErrorMessage",
+  [-1000]: "PhoneNumberBanned",
+  [400]: "BadRequest",
+  [401]: "Unauthorized",
+  [403]: "AccessForbidden",
+  [404]: "NotFound",
+  [409]: "Conflict",
+  [429]: "TooManyRequests",
+  [500]: "InternalServerError",
+  [4002]: "Web3AccountAlreadyLinkedToAnotherWallet",
+  [4003]: "Web3WalletAlreadyLinkedToAnotherAccount",
+  [4004]: "Web3AccountAlreadyLinkedToAnotherWallet2",
+  [4005]: "Web3PalLevelUpBattlesRequired",
+  [4006]: "Web3PalLevelUpMaximumLevelReached",
+  [4010]: "Web3PalPoolCooldown",
+  [4011]: "Web3PalPoolEmpty",
+  [4012]: "Web3PalAlreadyBattle",
+  [4017]: "Web3WalletHasPendingTransactions",
+  [5003]: "Web3WalletNetworkError",
+  [6001]: "Web3EMPLInsufficientFunds",
+  [6002]: "Web3EMPLFeeExceedsBalance",
+  [6004]: "Web3EMPLAmountInsufficientToCoverGasFee",
+  [6007]: "Web3EMPLInsufficientNativeBalance",
+  [6008]: "Web3EMPLExchangeExceedsRemainingQuota",
+  [10000]: "Offline",
+  [10001]: "CallOpponentDisabled",
+};
+
+// errorCodeName returns the canonical name (e.g. "UserNotFound");
+// an unrecognized code renders as "ErrorCode(<n>)".
+export function errorCodeName(c: ErrorCode): string {
+  return NAMES[c] ?? `ErrorCode(${c})`;
+}

--- a/packages/typescript/src/errors.ts
+++ b/packages/typescript/src/errors.ts
@@ -3,6 +3,7 @@
 // dispatch.
 
 import { ResponseError, FetchError } from "./gen/runtime";
+import { type ErrorCode, ErrCodeUnknown } from "./error_codes";
 
 // APIError carries the raw HTTP body and status. typescript-fetch already
 // throws `ResponseError` (a non-2xx HTTP response) and `FetchError` (a
@@ -61,13 +62,13 @@ export function errorResponseOf(err: unknown): ErrorResponse | null {
   }
 }
 
-// codeOf surfaces the server's error_code for switch dispatch. Returns 0
-// (ErrCodeUnknown placeholder) when the error is not an APIError or carries
-// no recognizable code. The typed ErrorCode constants are generated —
-// until that lands the port returns numeric codes only.
-export function codeOf(err: unknown): number {
+// codeOf surfaces the server's error_code for switch dispatch. Returns
+// ErrCodeUnknown (0) when the error is not an APIError or carries no
+// recognizable code. Compare the result against the ErrorCode constants
+// (e.g. `codeOf(err) === ErrCodeRequired2FA`).
+export function codeOf(err: unknown): ErrorCode {
   const r = errorResponseOf(err);
-  return r?.errorCode ?? 0;
+  return (r?.errorCode ?? ErrCodeUnknown) as ErrorCode;
 }
 
 // asAPIError converts a typescript-fetch thrown error (ResponseError or

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -32,6 +32,8 @@ export {
   asAPIError,
 } from "./errors";
 
+export * from "./error_codes";
+
 export {
   DEFAULT_API_KEY,
   DEFAULT_API_VERSION_KEY,

--- a/packages/typescript/src/transport.ts
+++ b/packages/typescript/src/transport.ts
@@ -104,6 +104,32 @@ export function buildHostRoutingMiddleware(ctx: HostRoutingContext): Middleware 
   };
 }
 
+const TIMESTAMP_PATH = "/v2/users/timestamp";
+
+function isTimestampPath(url: string): boolean {
+  return url.includes(TIMESTAMP_PATH);
+}
+
+// buildClientIPMiddleware triggers a one-shot, best-effort lookup of the
+// caller's outbound IP after the first request that isn't the lookup
+// endpoint itself (which would recurse). The lookup runs in the
+// background: the request that triggered it goes out without
+// X-Client-IP, and the value is learned from the lookup response so
+// subsequent requests carry the X-Client-IP header. A failed lookup
+// leaves the value empty and the next request tries again.
+export function buildClientIPMiddleware(ctx: {
+  maybeFetchClientIP(): void;
+}): Middleware {
+  return {
+    post: async (rc: ResponseContext): Promise<Response | void> => {
+      if (!isTimestampPath(rc.url)) {
+        ctx.maybeFetchClientIP();
+      }
+      return undefined;
+    },
+  };
+}
+
 function setIfAbsent(headers: Record<string, string>, key: string, value: string) {
   // Header keys in fetch's Record<string,string> form are case-sensitive in
   // practice; the runtime canonicalizes on send. We mirror the Go transport

--- a/packages/typescript/tests/auth_extra.test.ts
+++ b/packages/typescript/tests/auth_extra.test.ts
@@ -1,0 +1,156 @@
+// LoginWithEmail error-path parity (PORTING.md §15 #3 / #5).
+//
+//   #3  a session-store load failure that is NOT a cache miss must
+//       surface the error WITHOUT any HTTP being issued — this is the
+//       rate-limit protection: a corrupt/locked store must not turn into
+//       a flood of login attempts.
+//   #5  a 2FA-required login returns the server's error envelope; the
+//       caller can branch on it via codeOf(err) === ErrCodeRequired2FA.
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { Client } from "../src/client";
+import { codeOf } from "../src/errors";
+import { ErrCodeRequired2FA } from "../src/error_codes";
+import type { Session, SessionStore } from "../src/session";
+
+let failed = 0;
+function assert(name: string, cond: boolean, detail = ""): void {
+  if (cond) console.log(`PASS ${name}`);
+  else {
+    failed++;
+    console.log(`FAIL ${name}${detail ? `\n  ${detail}` : ""}`);
+  }
+}
+
+async function withServer(
+  handler: (path: string, body: string) => { status: number; body: string },
+  fn: (baseURL: string, hits: () => number) => Promise<void>,
+): Promise<void> {
+  let hitCount = 0;
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      hitCount++;
+      const out = handler(req.url ?? "", Buffer.concat(chunks).toString("utf8"));
+      res.writeHead(out.status, { "Content-Type": "application/json" });
+      res.end(out.body);
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, r));
+  const baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  try {
+    await fn(baseURL, () => hitCount);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+}
+
+// #3 — a store whose load() throws a non-"not found" error. The login
+// must reject and never touch the network.
+async function loadErrorReturnsErrorWithoutHTTP(): Promise<void> {
+  await withServer(
+    () => ({ status: 500, body: '{"error_code":-1}' }),
+    async (baseURL, hits) => {
+      // A SessionStore whose load fails with something other than a
+      // NoSessionError (e.g. a corrupt/locked store).
+      const brokenStore: SessionStore = {
+        load: async (): Promise<Session> => {
+          throw new Error("corrupt JSON");
+        },
+        save: async () => undefined,
+        delete: async () => undefined,
+      };
+      const c = new Client({ baseURL, sessionStore: brokenStore });
+
+      let caught: unknown = null;
+      try {
+        await c
+          .loginWithEmail()
+          .email("foo@example.com")
+          .password("pw")
+          .execute();
+      } catch (err) {
+        caught = err;
+      }
+
+      assert("load error surfaces an error", caught instanceof Error);
+      assert(
+        "load error message is not swallowed",
+        caught instanceof Error && /corrupt JSON/.test(caught.message),
+        caught instanceof Error ? caught.message : String(caught),
+      );
+      assert(
+        "no HTTP issued on store error (rate-limit protection)",
+        hits() === 0,
+        `server hits=${hits()}`,
+      );
+      assert(
+        "tokens not set after a broken-store login",
+        c.tokens().access === "",
+        c.tokens().access,
+      );
+    },
+  );
+}
+
+// #5 — the login endpoint returns the server's error envelope with the
+// 2FA code; codeOf(err) resolves it to the exported ErrCodeRequired2FA
+// constant (value sourced from the SDK, not hardcoded here).
+async function twoFARequiredSurfacesErrorCode(): Promise<void> {
+  await withServer(
+    (path) => {
+      if (!path.endsWith("/login_with_email")) {
+        return { status: 404, body: '{"status":404,"error":"Not Found"}' };
+      }
+      return {
+        status: 401,
+        body: JSON.stringify({
+          error_code: ErrCodeRequired2FA,
+          message: "2FA required",
+        }),
+      };
+    },
+    async (baseURL) => {
+      const c = new Client({
+        baseURL,
+        retryPolicy: { maxAttempts: 0, baseDelay: 1, maxDelay: 1, retryOnPOST: false },
+      });
+
+      let caught: unknown = null;
+      try {
+        await c
+          .loginWithEmail()
+          .email("u@example.com")
+          .password("pw")
+          .execute();
+      } catch (err) {
+        caught = err;
+      }
+
+      assert("2FA-required login rejects", caught != null);
+      assert(
+        "codeOf(err) === ErrCodeRequired2FA",
+        codeOf(caught) === ErrCodeRequired2FA,
+        `codeOf=${codeOf(caught)} want=${ErrCodeRequired2FA}`,
+      );
+      assert(
+        "tokens not set on 2FA-required",
+        c.tokens().access === "",
+        c.tokens().access,
+      );
+    },
+  );
+}
+
+(async () => {
+  await loadErrorReturnsErrorWithoutHTTP();
+  await twoFARequiredSurfacesErrorCode();
+  process.exit(failed === 0 ? 0 : 1);
+})().catch((e) => {
+  console.error("test crashed:", e);
+  process.exit(2);
+});

--- a/packages/typescript/tests/enum_tolerance.test.ts
+++ b/packages/typescript/tests/enum_tolerance.test.ts
@@ -1,0 +1,59 @@
+// Enum decode tolerance (PORTING.md §15 #26).
+//
+// The server may return an enum value the SDK doesn't know about. Typed
+// JSON decode must NOT reject it — an unknown value round-trips through
+// as the raw string, while a known value decodes to its typed constant.
+// This is a pure local-decode check; no server is involved.
+
+import { PostFromJSON } from "../src/gen/models/Post";
+import { PostType } from "../src/gen/models/PostType";
+
+let failed = 0;
+function assert(name: string, cond: boolean, detail = ""): void {
+  if (cond) console.log(`PASS ${name}`);
+  else {
+    failed++;
+    console.log(`FAIL ${name}${detail ? `\n  ${detail}` : ""}`);
+  }
+}
+
+function unknownEnumDoesNotThrow(): void {
+  let threw = false;
+  let decoded: unknown;
+  try {
+    decoded = PostFromJSON({ post_type: "__mock_unknown_enum__" });
+  } catch {
+    threw = true;
+  }
+  assert("unknown enum value does not throw on decode", !threw);
+  assert(
+    "unknown enum value round-trips as the raw string",
+    !threw && (decoded as { postType?: unknown }).postType === "__mock_unknown_enum__",
+    String((decoded as { postType?: unknown })?.postType),
+  );
+}
+
+function knownEnumDecodesToConstant(): void {
+  const post = PostFromJSON({ post_type: "image" });
+  assert(
+    "known enum value decodes to the typed constant",
+    post.postType === PostType.Image,
+    String(post.postType),
+  );
+  // The decoded value is usable in an equality switch against the
+  // exported constant set.
+  assert(
+    "decoded constant compares equal to PostType.Image",
+    post.postType === "image",
+    String(post.postType),
+  );
+}
+
+(async () => {
+  unknownEnumDoesNotThrow();
+  knownEnumDecodesToConstant();
+  process.exit(failed === 0 ? 0 : 1);
+})().catch((e) => {
+  console.error("test crashed:", e);
+  process.exit(2);
+});

--- a/packages/typescript/tests/transport.test.ts
+++ b/packages/typescript/tests/transport.test.ts
@@ -1,0 +1,284 @@
+// Transport behavior parity (PORTING.md §15 #6a / #6b / #10 / #9).
+//
+// These exercise the request-shaping the SDK guarantees on every
+// outbound call against an in-process HTTP server stub:
+//
+//   #6a  the required headers (User-Agent / X-App-Version / X-Device-*
+//        / X-Connection-* / Accept-Language / X-Timestamp) ride every
+//        request.
+//   #6b  the OAuth token endpoint gets `Authorization: Basic`, while a
+//        normal endpoint gets `Authorization: Bearer` once tokens are
+//        set.
+//   #10  the caller's outbound IP is learned lazily: the first request
+//        carries no X-Client-IP, and a later request does once the SDK
+//        has observed it from a server response.
+//   #9   a 401 that refreshes successfully but whose retried original
+//        then hits a transport error surfaces that transport error —
+//        never a stale 401.
+
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { Client } from "../src/client";
+
+let failed = 0;
+function assert(name: string, cond: boolean, detail = ""): void {
+  if (cond) console.log(`PASS ${name}`);
+  else {
+    failed++;
+    console.log(`FAIL ${name}${detail ? `\n  ${detail}` : ""}`);
+  }
+}
+
+interface Captured {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+}
+
+type Reply = { status: number; body: string; headers?: Record<string, string> };
+type HandlerFn = (req: Captured, body: string) => Reply | "destroy";
+
+// withServer runs an in-process server that records every request's
+// method / path / headers, then defers the response to the handler. A
+// handler returning "destroy" kills the socket so the client sees a
+// transport-level failure (the TS analogue of the Go test hijacking and
+// closing the TCP connection on the post-refresh retry).
+async function withServer(
+  handler: HandlerFn,
+  fn: (baseURL: string, captured: Captured[]) => Promise<void>,
+): Promise<void> {
+  const captured: Captured[] = [];
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries(req.headers)) {
+        if (typeof v === "string") headers[k.toLowerCase()] = v;
+        else if (Array.isArray(v)) headers[k.toLowerCase()] = v.join(", ");
+      }
+      const rec: Captured = {
+        method: req.method ?? "GET",
+        path: (req.url ?? "").split("?")[0],
+        headers,
+      };
+      captured.push(rec);
+      const out = handler(rec, Buffer.concat(chunks).toString("utf8"));
+      if (out === "destroy") {
+        req.socket.destroy();
+        return;
+      }
+      res.writeHead(out.status, {
+        "Content-Type": "application/json",
+        ...(out.headers ?? {}),
+      });
+      res.end(out.body);
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, r));
+  const baseURL = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  try {
+    await fn(baseURL, captured);
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+}
+
+const NO_RETRY = { maxAttempts: 0, baseDelay: 1, maxDelay: 1, retryOnPOST: false };
+
+function get(headers: Record<string, string>, key: string): string {
+  return headers[key.toLowerCase()] ?? "";
+}
+
+// #6a — every request carries the required headers; with tokens set the
+// Authorization scheme is Bearer on a normal endpoint.
+async function requiredHeadersInjected(): Promise<void> {
+  await withServer(
+    () => ({ status: 200, body: "{}" }),
+    async (baseURL, captured) => {
+      const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+      c.setTokens("ACC", "REF");
+      await c.bucketsAPI.getBucketPresignedUrls({ fileNames: [] });
+
+      const h = captured[0].headers;
+      for (const name of [
+        "User-Agent",
+        "X-App-Version",
+        "X-Device-Info",
+        "X-Device-UUID",
+        "X-Connection-Type",
+        "X-Connection-Speed",
+        "Accept-Language",
+        "X-Timestamp",
+      ]) {
+        assert(`required header present: ${name}`, get(h, name) !== "", `${name} empty`);
+      }
+      assert(
+        "Authorization is Bearer on a normal endpoint",
+        get(h, "Authorization") === "Bearer ACC",
+        get(h, "Authorization"),
+      );
+    },
+  );
+}
+
+// #6b — the OAuth token endpoint gets Basic; a normal endpoint gets
+// Bearer. Asserted on the same client so the scheme selection is the
+// transport's, not the caller's.
+async function oauthEndpointUsesBasicAuth(): Promise<void> {
+  await withServer(
+    (req) => {
+      if (req.path === "/api/v1/oauth/token") {
+        return {
+          status: 200,
+          body: JSON.stringify({ access_token: "A", refresh_token: "R" }),
+        };
+      }
+      return { status: 200, body: "{}" };
+    },
+    async (baseURL, captured) => {
+      const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+      c.setTokens("ACC", "REF");
+
+      await c.authAPI.oauthToken({ grantType: "refresh_token", refreshToken: "R" });
+      await c.bucketsAPI.getBucketPresignedUrls({ fileNames: [] });
+
+      const oauthReq = captured.find((r) => r.path === "/api/v1/oauth/token");
+      const normalReq = captured.find((r) => r.path === "/v1/buckets/presigned_urls");
+      assert("oauth request captured", oauthReq !== undefined);
+      assert("normal request captured", normalReq !== undefined);
+
+      const oauthAuth = get(oauthReq!.headers, "Authorization");
+      const expectedBasic = `Basic ${Buffer.from(c.apiKey).toString("base64")}`;
+      assert(
+        "oauth endpoint Authorization is Basic <base64(apiKey)>",
+        oauthAuth === expectedBasic,
+        `got=${oauthAuth} want=${expectedBasic}`,
+      );
+      assert(
+        "normal endpoint Authorization is Bearer after setTokens",
+        get(normalReq!.headers, "Authorization") === "Bearer ACC",
+        get(normalReq!.headers, "Authorization"),
+      );
+    },
+  );
+}
+
+// #10 — lazy X-Client-IP. The first request carries none; the SDK learns
+// the IP from the timestamp lookup response; a later request carries it.
+async function lazyClientIPPopulatesHeader(): Promise<void> {
+  const FETCHED_IP = "203.0.113.7";
+  await withServer(
+    (req) => {
+      if (req.path.endsWith("/v2/users/timestamp")) {
+        return {
+          status: 200,
+          body: JSON.stringify({ time: 0, ip_address: FETCHED_IP }),
+        };
+      }
+      return { status: 200, body: "{}" };
+    },
+    async (baseURL, captured) => {
+      const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+
+      // First request kicks off the background IP lookup; it goes out
+      // without X-Client-IP.
+      await c.bucketsAPI.getBucketPresignedUrls({ fileNames: [] });
+
+      // Wait until the SDK has observed the IP (or time out).
+      const deadline = Date.now() + 2000;
+      while (Date.now() < deadline && c.clientIP !== FETCHED_IP) {
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      assert(
+        "client IP learned from lookup response",
+        c.clientIP === FETCHED_IP,
+        `clientIP=${c.clientIP}`,
+      );
+
+      // Second request now carries the learned X-Client-IP.
+      await c.bucketsAPI.getBucketPresignedUrls({ fileNames: [] });
+
+      const bucketReqs = captured.filter(
+        (r) => r.path === "/v1/buckets/presigned_urls",
+      );
+      const first = bucketReqs[0];
+      const second = bucketReqs[bucketReqs.length - 1];
+      assert(
+        "first request carries no X-Client-IP (lookup is async)",
+        get(first.headers, "X-Client-IP") === "",
+        get(first.headers, "X-Client-IP"),
+      );
+      assert(
+        "second request carries the learned X-Client-IP",
+        get(second.headers, "X-Client-IP") === FETCHED_IP,
+        get(second.headers, "X-Client-IP"),
+      );
+    },
+  );
+}
+
+// #9 — 401 → refresh succeeds → retried original hits a transport error.
+// The surfaced error must be the retry/network error, not a stale 401.
+async function refreshOkButRetryNetworkErrorSurfaces(): Promise<void> {
+  let dataAttempt = 0;
+  await withServer(
+    (req): Reply | "destroy" => {
+      if (req.path === "/api/v1/oauth/token") {
+        return {
+          status: 200,
+          body: JSON.stringify({
+            access_token: "NEW_ACC",
+            refresh_token: "NEW_REF",
+          }),
+        };
+      }
+      dataAttempt++;
+      if (dataAttempt === 1) {
+        return { status: 401, body: '{"error_code":-3,"message":"expired"}' };
+      }
+      // Post-refresh retry: kill the socket so fetch rejects with a
+      // transport error.
+      return "destroy";
+    },
+    async (baseURL) => {
+      const c = new Client({ baseURL, retryPolicy: NO_RETRY });
+      c.setTokens("STALE", "REF");
+
+      let threw = false;
+      let status401 = false;
+      try {
+        await c.bucketsAPI.getBucketPresignedUrls({ fileNames: [] });
+      } catch (err) {
+        threw = true;
+        // A surfaced ResponseError/APIError carrying a 401 would mean
+        // the stale 401 leaked — assert it did not.
+        const anyErr = err as { response?: { status?: number } };
+        status401 = anyErr.response?.status === 401;
+      }
+      assert("broken retry surfaces an error", threw);
+      assert(
+        "surfaced error is the transport failure, not a stale 401",
+        threw && !status401,
+      );
+      assert(
+        "tokens stayed rotated after the successful refresh",
+        c.tokens().access === "NEW_ACC",
+        `access=${c.tokens().access}`,
+      );
+    },
+  );
+}
+
+(async () => {
+  await requiredHeadersInjected();
+  await oauthEndpointUsesBasicAuth();
+  await lazyClientIPPopulatesHeader();
+  await refreshOkButRetryNetworkErrorSurfaces();
+  process.exit(failed === 0 ? 0 : 1);
+})().catch((e) => {
+  console.error("test crashed:", e);
+  process.exit(2);
+});


### PR DESCRIPTION
Closes the remaining §15 cross-language behavior-parity gaps so every contract scenario is exercised in all three clients.

**Parity scenarios added**
- Unknown enum value in a response is accepted (typed field keeps the unknown string, no error; membership/IsValid false; typed constants stay usable) — Go, TS, Python.
- The raw escape hatch on a typed-decode-failing 2xx body: the typed call raises an APIError that **retains the raw body**; `ExecuteRaw`/`executeRaw`/`execute_raw` returns `(body, response)` without raising — Go, TS, Python.
- TS local-fixture scenarios that previously had no TS counterpart: required-header injection + OAuth `Basic` vs `Bearer`, lazy `X-Client-IP`, 401→refresh→retry-network-error (surfaces the retry error, not a stale 401), login store-load error (no HTTP), 2FA-required → typed code.

**SDK work this surfaced (parity defects, now fixed)**
- Typed error-code constants existed only in Go. They are now emitted for all three languages (`error_codes.go` / `error_codes.ts` / `_error_codes.py`); `codeOf`/`code_of` resolve against them. TS/Python previously returned a bare number.
- Python had no working raw escape hatch (the buffered transport didn't expose the response the generated raw sibling expected) and a 2xx body the typed model rejected raised a bare validation error with no body. Now: `BufferedResponse.response` is exposed, `Client.execute_raw` added, and a 2xx decode failure surfaces as an APIError carrying the raw body — matching Go/TS.
- TS lazy `X-Client-IP` fetch was unimplemented; implemented to match the documented behavior.

**Verification**
- Go `go test ./.` green; TS `npm test` 214 PASS / 0 FAIL; Python suite **102 passed** under the shared mock server (76 passed / 26 mock-gated skipped standalone). No regressions.
- New generated files are marked `linguist-generated` in `.gitattributes`.