### PR TITLE
feat(event-stream): symmetric raw/catch-all + terminal-cause contract

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -503,16 +503,36 @@ on top.
 
 Common surface (same shape, language-idiomatic API):
 
+The concepts and names are identical; the call shape and the dispatch
+idiom follow each language (§2). Function/constructor casing is
+idiomatic (`ChatRoomChannel()` / `chatRoomChannel()` /
+`chat_room_channel()`), not copied across.
+
 | Concept | Go | TS | Python |
 |---|---|---|---|
 | Open the stream | `client.OpenEventStream(ctx, opts...)` | `await client.openEventStream(opts)` | `async with client.open_event_stream(opts) as stream` |
-| Subscribe | `stream.Subscribe(ctx, ChatRoomChannel())` | `await stream.subscribe(ChatRoomChannel())` | `await stream.subscribe(ChatRoomChannel())` |
-| Receive events | `for ev := range sub.Events() { ... }` | `sub.onNewMessage(ev => ...)` | `@sub.on_new_message` decorator |
+| Subscribe | `stream.Subscribe(ctx, ChatRoomChannel())` | `await stream.subscribe(chatRoomChannel())` | `await stream.subscribe(chat_room_channel())` |
+| Receive (typed) | `for ev := range sub.Events()` + type switch | `sub.onNewMessage(ev => ...)` | `@sub.on_new_message` decorator |
+| Receive (catch-all / unknown) | the same `Events()` channel delivers every event incl. `*RawEvent` | `sub.onEvent(...)` / `sub.onRaw(...)` | `@sub.on_event` / `@sub.on_raw` |
 | Unsubscribe | `sub.Unsubscribe(ctx)` | `await sub.unsubscribe()` | `await sub.unsubscribe()` |
 | Close stream | `stream.Close()` | `await stream.close()` | exit `async with` |
+| Terminal cause / done | `stream.Err()` after `sub.Done()` | `stream.err()` after `await stream.done()` | `stream.err()` after `await stream.wait_done()` |
 
-The dispatch idiom differs by language but the underlying event
-inventory is fixed:
+**RawEvent MUST be observable via each language's *primary*
+subscription API**, not only a lower-level pull: an event the SDK
+doesn't model still reaches the Go channel, TS `onRaw`/`onEvent`, and
+Python `on_raw`/`on_event`. The dispatch idiom differs by language but
+the event inventory below is fixed and fully reachable everywhere.
+
+**Terminal-cause contract.** When the stream ends, the cause MUST be
+recoverable: the stream exposes a terminal-error accessor
+(`Err()` / `err()` / `err()`) that returns the failure that ended it
+(nil/undefined/None for a caller-initiated `close`), available once the
+stream's done signal has fired; a subscription independently exposes a
+closed/done signal (`Done()` / `closed` / `closed`+`wait_done`). A port
+that ends the stream without a recoverable cause is non-conformant.
+
+The underlying event inventory is fixed:
 
 | Wire `event` | SDK type name |
 |---|---|
@@ -964,6 +984,18 @@ Client surface (§2):
   `login_with_email` is the cached wrapper — calling it with empty
   credentials fails fast with the wrapper's validation error, not an
   HTTP attempt).
+
+Event stream (§10):
+
+- **S34** A wire event the SDK does not model is delivered as
+  `RawEvent` and is observable through the language's *primary*
+  subscription API (Go: the `Events()` channel yields `*RawEvent`;
+  TS: `onRaw` / `onEvent` fire; Python: `on_raw` / `on_event` fire) —
+  not only via a lower-level pull.
+- **S35** After the stream ends on its own (e.g. reconnect
+  exhausted), the terminal cause is recoverable from the stream's
+  error accessor (`Err()` / `err()` / `err()`); a caller-initiated
+  `close()` reports no error.
 
 **Scope notes (deliberate boundaries, not gaps):**
 

--- a/event_stream_test.go
+++ b/event_stream_test.go
@@ -158,6 +158,63 @@ func TestEventStream_Unsubscribe(t *testing.T) {
 	}
 }
 
+// PORTING:S34
+func TestEventStream_UnknownEventDeliveredAsRaw(t *testing.T) {
+	const ident = `{"channel":"ChatRoomChannel"}`
+	fs := newFakeServer(t, func(s *wsSession) {
+		s.sendWelcome()
+		msg := <-s.received
+		s.confirm(msg["identifier"])
+		// Push an event whose wire name the SDK does not model. It must
+		// surface through the primary subscription API, not be dropped.
+		s.pushEvent(ident, "__unknown_evt__", map[string]any{
+			"foo": "bar",
+			"n":   42,
+		})
+		<-s.ctx.Done()
+	})
+
+	c := newStreamTestClient(fs.srv.URL)
+	c.SetTokens("stub", "")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := c.OpenEventStream(ctx, EventStreamOptions{Reconnect: ReconnectPolicy{Disabled: true}})
+	if err != nil {
+		t.Fatalf("OpenEventStream: %v", err)
+	}
+	defer conn.Close()
+
+	sub, err := conn.Subscribe(ctx, ChatRoomChannel())
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	select {
+	case ev := <-sub.Events():
+		raw, ok := ev.(*RawEvent)
+		if !ok {
+			t.Fatalf("event = %T, want *RawEvent", ev)
+		}
+		if raw.Name != "__unknown_evt__" {
+			t.Errorf("RawEvent.Name = %q, want %q", raw.Name, "__unknown_evt__")
+		}
+		var got map[string]any
+		if err := json.Unmarshal(raw.Data, &got); err != nil {
+			t.Fatalf("RawEvent.Data is not decodable JSON: %v", err)
+		}
+		if got["foo"] != "bar" {
+			t.Errorf("RawEvent.Data foo = %v, want \"bar\"", got["foo"])
+		}
+		if n, _ := got["n"].(float64); n != 42 {
+			t.Errorf("RawEvent.Data n = %v, want 42", got["n"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no event received over the primary Events() channel")
+	}
+}
+
+// PORTING:S35
 func TestEventStream_ErrAfterReconnectExhausted(t *testing.T) {
 	fs := newFakeServer(t, func(s *wsSession) {
 		s.sendWelcome()

--- a/packages/python/tests/test_event_stream.py
+++ b/packages/python/tests/test_event_stream.py
@@ -54,6 +54,49 @@ async def test_subscribe_and_receive_event():
             await client.close()
 
 
+# PORTING:S34
+async def test_unknown_event_observable_via_on_raw_and_on_event():
+    # An unmodelled wire event must still surface through the primary
+    # subscription API as a RawEvent carrying its raw name and data.
+    async def on_connect(s):
+        await s.send_welcome()
+        msg = await s.received.get()
+        await s.confirm(msg["identifier"])
+        await s.push_event(
+            msg["identifier"],
+            "__unknown_evt__",
+            {"foo": "bar", "n": 7},
+        )
+        await s.idle()
+
+    async with serve_ws(on_connect) as base_url:
+        client = _client(base_url)
+        try:
+            async with client.open_event_stream(_DISABLED) as stream:
+                sub = await stream.subscribe(chat_room_channel())
+
+                raw_seen = asyncio.Queue()
+                any_seen = asyncio.Queue()
+
+                @sub.on_raw
+                def _r(ev):
+                    raw_seen.put_nowait(ev)
+
+                @sub.on_event
+                def _a(ev):
+                    any_seen.put_nowait(ev)
+
+                raw_ev = await asyncio.wait_for(raw_seen.get(), timeout=2)
+                any_ev = await asyncio.wait_for(any_seen.get(), timeout=2)
+
+                for ev in (raw_ev, any_ev):
+                    assert isinstance(ev, es.RawEvent)
+                    assert ev.name == "__unknown_evt__"
+                    assert ev.data == {"foo": "bar", "n": 7}
+        finally:
+            await client.close()
+
+
 # PORTING:S21
 async def test_rejected_subscription():
     async def on_connect(s):
@@ -204,6 +247,7 @@ async def test_done_and_err_on_clean_close():
             await client.close()
 
 
+# PORTING:S35
 async def test_err_after_reconnect_exhausted():
     async def on_connect(s):
         await s.send_welcome()

--- a/packages/python/yaylib/event_stream.py
+++ b/packages/python/yaylib/event_stream.py
@@ -305,9 +305,21 @@ class Subscription:
                 item = await self._queue.get()
                 if item is _CLOSED:
                     return
-                wire = _TYPE_TO_WIRE.get(type(item))
-                for cb in self._handlers.get(wire or "", []):
+                # Catch-all sees every event (incl. RawEvent); on_raw
+                # sees unknown/raw events; the typed on_<event> sees its
+                # own. A known event reaches "*" + its typed handler; an
+                # unknown one reaches "*" + on_raw — so RawEvent stays
+                # observable via this primary (push) API, matching the
+                # Go channel and the TS onEvent/onRaw.
+                for cb in self._handlers.get("*", []):
                     self._spawn_handler(cb, item)
+                if isinstance(item, RawEvent):
+                    for cb in self._handlers.get("__raw__", []):
+                        self._spawn_handler(cb, item)
+                wire = _TYPE_TO_WIRE.get(type(item))
+                if wire:
+                    for cb in self._handlers.get(wire, []):
+                        self._spawn_handler(cb, item)
         except asyncio.CancelledError:
             raise
 
@@ -331,6 +343,18 @@ class Subscription:
 
     def on_call_finished(self, fn):
         return self._register("conference_call_finished", fn)
+
+    def on_event(self, fn):
+        """Catch-all: every event, including RawEvent. Mirrors the Go
+        channel and the TS onEvent."""
+        return self._register("*", fn)
+
+    def on_raw(self, fn):
+        """Unknown / unmodelled wire events (RawEvent). Without this an
+        event the SDK doesn't model would be unreachable from the
+        decorator API (PORTING.md §10: the event inventory is fixed and
+        RawEvent must stay observable in every language)."""
+        return self._register("__raw__", fn)
 
     # ---- delivery (read-pump side) ----
 

--- a/packages/typescript/tests/event_stream.test.ts
+++ b/packages/typescript/tests/event_stream.test.ts
@@ -8,6 +8,7 @@ import type { AddressInfo } from "node:net";
 
 import { Client } from "../src/client";
 import { noopLogger } from "../src/logger";
+import type { Event } from "../src/events";
 import {
   type EventStream,
   type WebSocketLike,
@@ -167,6 +168,56 @@ async function subscribeAndReceiveEvent(): Promise<void> {
   await conn.close();
 }
 
+// PORTING:S34
+// An event whose wire name the SDK does not model must still reach the
+// caller through the primary subscription API as a RawEvent — onRaw and
+// the catch-all onEvent both fire, carrying the unrecognized name + data
+// verbatim so new server signals are observable before the SDK is taught
+// about them.
+async function unmodelledEventDeliveredAsRaw(): Promise<void> {
+  const hub = new Hub((s) => {
+    s.welcome();
+    void (async () => {
+      const msg = await s.next();
+      s.confirm(msg.identifier as string);
+      s.pushEvent(msg.identifier as string, "__unknown_evt__", {
+        foo: "bar",
+        n: 7,
+      });
+    })();
+  });
+  const conn = await openEventStream(streamDeps(hub), { reconnect: { disabled: true } });
+  const sub = await conn.subscribe(chatRoomChannel());
+  let raw: Event | undefined;
+  let any: Event | undefined;
+  sub.onRaw((ev) => {
+    raw = ev;
+  });
+  sub.onEvent((ev) => {
+    any = ev;
+  });
+  await waitUntil(() => raw !== undefined && any !== undefined);
+  assert("raw event: onRaw fired", raw !== undefined);
+  assert("raw event: onEvent fired", any !== undefined);
+  assert(
+    "raw event: delivered as RawEvent type",
+    raw?.type === "RawEvent" && any?.type === "RawEvent",
+    `raw=${raw?.type} any=${any?.type}`,
+  );
+  assert(
+    "raw event: carries the unmodelled wire name",
+    raw?.type === "RawEvent" && raw.name === "__unknown_evt__",
+    `name=${raw?.type === "RawEvent" ? raw.name : "n/a"}`,
+  );
+  assert(
+    "raw event: carries the original data payload",
+    raw?.type === "RawEvent" &&
+      JSON.stringify(raw.data) === JSON.stringify({ foo: "bar", n: 7 }),
+    `data=${raw?.type === "RawEvent" ? JSON.stringify(raw.data) : "n/a"}`,
+  );
+  await conn.close();
+}
+
 // PORTING:S21
 async function rejectedSubscription(): Promise<void> {
   const hub = new Hub((s) => {
@@ -299,6 +350,7 @@ async function doneAndErrOnCleanClose(): Promise<void> {
   assert("clean close: err() undefined after caller close", conn.err() === undefined);
 }
 
+// PORTING:S35
 async function errAfterReconnectExhausted(): Promise<void> {
   const hub = new Hub((s) => {
     s.welcome();
@@ -519,6 +571,7 @@ async function clientUnauthenticated401(): Promise<void> {
 
 (async () => {
   await subscribeAndReceiveEvent();
+  await unmodelledEventDeliveredAsRaw();
   await rejectedSubscription();
   await multipleChannels();
   await reconnectAfterServerClose();


### PR DESCRIPTION
An asymmetry audit of the event-stream surface (parallel to the login/facade work).

**Deliberate idiom differences are kept** (Go channel + type switch / TS `onXxx` / Python decorators) — §10 already sanctions these.

**Unintended asymmetries, now fixed:**
- **Raw/catch-all reachability.** Python exposed only the 7 typed `on_<event>` registrations, so an unmodelled wire event (`RawEvent`) was **unreachable from the primary decorator API** — Go's `Events()` channel and TS's `onRaw`/`onEvent` already surfaced it. Added `Subscription.on_event` (catch-all incl. `RawEvent`) and `on_raw`, dispatched in the pump. `RawEvent` is now observable via every language's primary subscription API (§10 inventory contract honoured).
- **Terminal-cause contract.** All three already exposed the cause (`Err()`/`err()`/`err()`) + a done/closed signal, but §10 didn't pin it (drift risk). §10 now states it as a contract.
- **§10 doc accuracy.** The surface table showed `ChatRoomChannel()` (PascalCase) for TS/Python; corrected to the real idiomatic `chatRoomChannel()` / `chat_room_channel()`, with explicit catch-all and terminal-cause rows (same class of fix as the login examples).

**Traceability:** §15 **S34** (RawEvent observable via the primary API) and **S35** (terminal cause recoverable after the stream dies) added and tagged across Go/TS/Python; `parity-matrix.sh` → **35/35**.

Code change is Python-only (the on_event/on_raw addition); Go/TS already conformed. Verified: Go `go test ./.` green; TS `npm test` 222 PASS / 0 FAIL (266 under the shared mock); Python 79 passed (106 mock); leak-grep clean. Submodule-only — no pipeline change.