### PR TITLE
chore: containerized development environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+# Containerized development for the SDK and its bundled mock server.
+#
+#   docker compose run --rm dev go test ./.
+#   docker compose run --rm dev bash scripts/mock-parity.sh
+#   docker compose run --rm dev bash          # interactive shell
+#   docker compose up mockd                   # mock server on :8080
+#
+# Source is bind-mounted; toolchains, caches and node_modules live in
+# named volumes, so nothing is installed on the host.
+
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: docker/dev/Dockerfile
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+    volumes:
+      - .:/workspace
+      - go-mod:/cache/go/mod
+      - go-build:/cache/go/build
+      - npm-cache:/cache/npm
+      - pip-cache:/cache/pip
+      # Keep node_modules in a volume so the bind mount never writes it
+      # to the host tree.
+      - ts-node-modules:/workspace/packages/typescript/node_modules
+    command: bash
+
+  mockd:
+    build:
+      context: .
+      dockerfile: docker/dev/Dockerfile
+    working_dir: /workspace/mockd
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/workspace
+      - go-mod:/cache/go/mod
+      - go-build:/cache/go/build
+    command: go run . -addr 0.0.0.0:8080
+
+volumes:
+  go-mod:
+  go-build:
+  npm-cache:
+  pip-cache:
+  ts-node-modules:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,39 @@
+# Containerized development
+
+Build, test and run everything without installing Go, Node or Python on
+the host. Source is bind-mounted; toolchains, caches and `node_modules`
+live in named Docker volumes, so the host tree stays clean.
+
+Requires Docker with Compose v2.
+
+## Run a command
+
+```sh
+docker compose run --rm dev go test ./.                 # Go hermetic suite
+docker compose run --rm dev sh -c 'cd packages/typescript && npm ci && npm test'
+docker compose run --rm dev sh -c 'cd packages/python && pip install -r requirements.txt -r requirements-dev.txt && PYTHONPATH="$PWD" python -m pytest -q'
+docker compose run --rm dev bash scripts/mock-parity.sh  # all three vs the mock server
+docker compose run --rm dev bash                         # interactive shell
+```
+
+## Mock server as a service
+
+```sh
+docker compose up mockd          # serves on http://localhost:8080
+```
+
+Point the suites at a running instance instead of letting the parity
+script boot its own:
+
+```sh
+docker compose run --rm \
+  -e YAYLIB_MOCK_BASE_URL=http://mockd:8080 \
+  -e YAYLIB_MOCK_WS_URL=ws://mockd:8080 \
+  dev go test ./.
+```
+
+## Reset
+
+```sh
+docker compose down -v           # remove the cache/node_modules volumes
+```

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,32 @@
+# Containerized development environment for the SDK and its bundled mock
+# server. Mirrors the CI matrix (Ubuntu 24.04 / Go / Node 22 /
+# Python 3.12) so a contributor can build, test and run everything
+# without installing any toolchain on the host.
+FROM ubuntu:24.04
+
+# Go is copied from the official image so the version is pinned without
+# guessing a download URL.
+COPY --from=golang:1.25-bookworm /usr/local/go /usr/local/go
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates curl git bash build-essential \
+      python3 python3-venv python3-pip \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/usr/local/go/bin:/go/bin:$PATH \
+    GOPATH=/go \
+    GOMODCACHE=/cache/go/mod \
+    GOCACHE=/cache/go/build \
+    NPM_CONFIG_CACHE=/cache/npm \
+    PIP_CACHE_DIR=/cache/pip \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /workspace
+
+# Interactive shell by default; the compose services override this with
+# the concrete command to run.
+CMD ["bash"]


### PR DESCRIPTION
Develop, test and run everything without installing Go, Node or Python on the host.

## What

- `docker/dev/Dockerfile` — Ubuntu 24.04 / Go / Node 22 / Python 3.12 (matches the CI matrix)
- `docker-compose.yml` — a `dev` service for running any command and a long-running `mockd` service on `:8080`
- `docker/README.md` — usage

Source is bind-mounted; toolchains, caches and `node_modules` live in named volumes, so the host tree stays clean.

## Examples

```sh
docker compose run --rm dev go test ./.
docker compose run --rm dev bash scripts/mock-parity.sh
docker compose up mockd          # http://localhost:8080
```

Validated: image builds, in-container go `1.25.x` / node `v22` / python `3.12`, the Go hermetic suite and the multi-module `mockd` build/test pass in-container, and `node_modules` stays off the host (named volume).